### PR TITLE
Datepicker should use Date as state model, (local-now) for determining today

### DIFF
--- a/src/re_com/datepicker.cljs
+++ b/src/re_com/datepicker.cljs
@@ -3,6 +3,7 @@
   (:require
     [reagent.core         :as    reagent]
     [cljs-time.core       :refer [now minus plus months days year month day day-of-week first-day-of-the-month before? after?]]
+    [cljs-time.local      :refer [local-now]]
     [re-com.validate      :refer [goog-date? css-style? html-attr?] :refer-macros [validate-args-macro]]
     [cljs-time.predicates :refer [sunday?]]
     [cljs-time.format     :refer [parse unparse formatters formatter]]
@@ -198,7 +199,7 @@
                           (map #(% {:Su 7 :Sa 6 :Fr 5 :Th 4 :We 3 :Tu 2 :Mo 1}))
                           set)]
     (merge attributes {:enabled-days enabled-days
-                       :today (now)})))
+                       :today (local-now)})))
 
 (def datepicker-args-desc
   [{:name :model        :required true                        :type "goog.date.UtcDateTime | atom"   :validate-fn goog-date? :description "the selected date. Should match :enabled-days"}

--- a/src/re_com/datepicker.cljs
+++ b/src/re_com/datepicker.cljs
@@ -93,7 +93,7 @@
   ;;TODO: We might choose later to style by removing arrows altogether instead of greying when disabled navigation
   (let [style         (fn [week-day] {:class (if (enabled-days week-day) "day-enabled" "day-disabled")})
         prev-date     (dec-month @current)
-        prev-enabled? (if minimum (after? prev-date minimum) true)
+        prev-enabled? (if minimum (after? prev-date (dec-month minimum)) true)
         next-date     (inc-month @current)
         next-enabled? (if maximum (before? next-date maximum) true)
         template-row  (if show-weeks? [:tr [:th]] [:tr])]

--- a/src/re_com/datepicker.cljs
+++ b/src/re_com/datepicker.cljs
@@ -3,6 +3,7 @@
   (:require
     [reagent.core         :as    reagent]
     [cljs-time.core       :refer [now minus plus months days year month day day-of-week first-day-of-the-month before? after?]]
+    [cljs-time.coerce     :refer [to-date-time]]
     [cljs-time.local      :refer [local-now]]
     [re-com.validate      :refer [goog-date? css-style? html-attr?] :refer-macros [validate-args-macro]]
     [cljs-time.predicates :refer [sunday?]]
@@ -107,7 +108,7 @@
              {:style    {:font-size "24px"}
               :on-click (handler-fn (when prev-enabled? (reset! current prev-date)))}]]
 
-           [:th {:class "month" :col-span "5"} (month-label @current)]
+           [:th {:class "month" :col-span "5"} (month-label (to-date-time @current))]
 
            #_[:th {:class (str "next " (if next-enabled? "available selectable" "disabled"))} ;; TODO: Remove
             [:i {:class    "glyphicon glyphicon-chevron-right"
@@ -202,14 +203,14 @@
                        :today (local-now)})))
 
 (def datepicker-args-desc
-  [{:name :model        :required true                        :type "goog.date.UtcDateTime | atom"   :validate-fn goog-date? :description "the selected date. Should match :enabled-days"}
-   {:name :on-change    :required true                        :type "goog.date.UtcDateTime -> nil"   :validate-fn fn?        :description "called when a new selection is made"}
+  [{:name :model        :required true                        :type "goog.date.Date | atom"   :validate-fn goog-date? :description "the selected date. Should match :enabled-days"}
+   {:name :on-change    :required true                        :type "(goog.date.Date) -> nil" :validate-fn fn?        :description "called when a new selection is made"}
    {:name :disabled?    :required false :default false        :type "boolean | atom"                                         :description "when true, the can't select dates but can navigate"}
    {:name :enabled-days :required false                       :type "set"                            :validate-fn set?       :description "a subset of #{:Su :Mo :Tu :We :Th :Fr :Sa}. Only dates falling on these days will be user-selectable. Default is all 7 days"}
    {:name :show-weeks?  :required false :default false        :type "boolean"                                                :description "when true, week numbers are shown to the left"}
    {:name :show-today?  :required false :default false        :type "boolean"                                                :description "when true, today's date is highlighted"}
-   {:name :minimum      :required false                       :type "goog.date.UtcDateTime"          :validate-fn goog-date? :description "no selection or navigation before this date"}
-   {:name :maximum      :required false                       :type "goog.date.UtcDateTime"          :validate-fn goog-date? :description "no selection or navigation after this date"}
+   {:name :minimum      :required false                       :type "goog.date.DateTime"          :validate-fn goog-date? :description "no selection or navigation before this date"}
+   {:name :maximum      :required false                       :type "goog.date.DateTime"          :validate-fn goog-date? :description "no selection or navigation after this date"}
    {:name :hide-border? :required false :default false        :type "boolean"                                                :description "when true, the border is not displayed"}
    {:name :class        :required false                       :type "string"                         :validate-fn string?    :description "CSS class names, space separated"}
    {:name :style        :required false                       :type "CSS style map"                  :validate-fn css-style? :description "CSS styles to add or override"}
@@ -248,7 +249,7 @@
     :align :center
     :class "noselect"
     :children [[:label {:class "form-control dropdown-button"}
-                (unparse (if (seq format) (formatter format) date-format) @model)]
+                (unparse (if (seq format) (formatter format) date-format) (to-date-time @model))]
                #_[:span  {:class "dropdown-button activator input-group-addon"} ;; TODO: Remove
                 [:i {:class "glyphicon glyphicon-th"}]]
                [:span.dropdown-button.activator.input-group-addon

--- a/src/re_com/validate.cljs
+++ b/src/re_com/validate.cljs
@@ -283,10 +283,10 @@
                   :message result}))))))
 
 (defn goog-date?
-  "Returns true if the passed argument is a valid goog.date.UtcDateTime, otherwise false/error"
+  "Returns true if the passed argument is a valid goog.date.DateTime, otherwise false/error"
   [arg]
   (let [arg (deref-or-value arg)]
-    (instance? goog.date.UtcDateTime arg)))
+    (instance? goog.date.Date arg)))
 
 (defn regex?
   "Returns true if the passed argument is a valid regular expression, otherwise false/error"


### PR DESCRIPTION
When determining the value of *today* for highlighting purposes, we should use (local-now) so that it matches the end user's current date as opposed to the current UTC date.

The underlying model used to store the current value of the Datepicker should be a Date object since the widget does not actually capture both a Date and a Time. This then allows the component user to further manipulate as needed without worrying about time zone conversions or other issues. 