### PR TITLE
Make re-com scrollers compatible with the spec

### DIFF
--- a/run/resources/public/assets/css/re-com.css
+++ b/run/resources/public/assets/css/re-com.css
@@ -12,6 +12,11 @@
   height of the browser window and setting some global defaults like font...
 ----------------------------------------------------------------------------------------*/
 
+* {
+	min-height:     0px;
+   	min-width:      0px;
+}
+
 html, body {
     font-family:    Segoe UI, Roboto, sans-serif;
     font-size:      14px;


### PR DESCRIPTION
`scroller` works in Chrome, but it seems to be because they haven't updated to the latest spec yet.
See this Firefox problem: http://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox

The solution, considering `re-com` is going all-in on flexbox anyway, would be to set the minimum height and width to 0.

I can confirm it fixes the scrollers for Firefox.