### PR TITLE
Access to backdrop :on-click event

### DIFF
--- a/src/re_com/modal_panel.cljs
+++ b/src/re_com/modal_panel.cljs
@@ -6,20 +6,21 @@
 ;; ------------------------------------------------------------------------------------
 
 (def modal-panel-args-desc
-  [{:name :child            :required true                   :type "string | hiccup" :validate-fn string-or-hiccup? :description "hiccup to be centered within in the browser window"}
-   {:name :wrap-nicely?     :required false :default true    :type "boolean"                                        :description [:span "if true, wrap " [:code ":child"] " in a white, rounded panel"]}
-   {:name :backdrop-color   :required false :default "black" :type "string"          :validate-fn string?           :description "CSS color of backdrop"}
-   {:name :backdrop-opacity :required false :default 0.6     :type "double | string" :validate-fn number-or-string? :description [:span "opacity of backdrop from:" [:br] "0.0 (transparent) to 1.0 (opaque)"]}
-   {:name :class            :required false                  :type "string"          :validate-fn string?           :description "CSS class names, space separated"}
-   {:name :style            :required false                  :type "CSS style map"   :validate-fn css-style?        :description "CSS styles to add or override"}
-   {:name :attr             :required false                  :type "HTML attr map"   :validate-fn html-attr?        :description [:span "HTML attributes, like " [:code ":on-mouse-move"] [:br] "No " [:code ":class"] " or " [:code ":style"] "allowed"]}])
+  [{:name :child             :required true                   :type "string | hiccup" :validate-fn string-or-hiccup? :description "hiccup to be centered within in the browser window"}
+   {:name :wrap-nicely?      :required false :default true    :type "boolean"                                        :description [:span "if true, wrap " [:code ":child"] " in a white, rounded panel"]}
+   {:name :backdrop-color    :required false :default "black" :type "string"          :validate-fn string?           :description "CSS color of backdrop"}
+   {:name :backdrop-opacity  :required false :default 0.6     :type "double | string" :validate-fn number-or-string? :description [:span "opacity of backdrop from:" [:br] "0.0 (transparent) to 1.0 (opaque)"]}
+   {:name :class             :required false                  :type "string"          :validate-fn string?           :description "CSS class names, space separated"}
+   {:name :style             :required false                  :type "CSS style map"   :validate-fn css-style?        :description "CSS styles to add or override"}
+   {:name :attr              :required false                  :type "HTML attr map"   :validate-fn html-attr?        :description [:span "HTML attributes, like " [:code ":on-mouse-move"] [:br] "No " [:code ":class"] " or " [:code ":style"] "allowed"]}
+   {:name :backdrop-on-click :required false :default nil     :type "-> nil"          :validate-fn fn?               :description "a function which takes no params and returns nothing. Called when the backdrop is clicked"}  ])
 
 (defn modal-panel
   "Renders a modal window centered on screen. A dark transparent backdrop sits between this and the underlying
    main window to prevent UI interactivity and place user focus on the modal window.
    Parameters:
     - child:  The message to display in the modal (a string or a hiccup vector or function returning a hiccup vector)"
-  [& {:keys [child wrap-nicely? backdrop-color backdrop-opacity class style attr]
+  [& {:keys [child wrap-nicely? backdrop-color backdrop-opacity class style attr backdrop-on-click]
       :or   {wrap-nicely? true backdrop-color "black" backdrop-opacity 0.6}
       :as   args}]
   {:pre [(validate-args-macro modal-panel-args-desc args "modal-panel")]}
@@ -40,8 +41,10 @@
                   :background-color backdrop-color
                   :opacity          backdrop-opacity
                   :z-index          1020
-                  :pointer-events   "none"}           ;; TODO: trying to prevent change of focus under the bwhen clicking on backdrop (also with the on-click below). Remove!
-       :on-click #(do (println "stopping propagation") (.preventDefault %) (.stopPropagation %))
+                  ;:pointer-events   "none"
+                  }           ;; TODO: trying to prevent change of focus under the bwhen clicking on backdrop (also with the on-click below). Remove!
+       :on-click #(do (when backdrop-on-click (backdrop-on-click))
+                      (println "stopping propagation") (.preventDefault %) (.stopPropagation %))
        }]
      [:div
       {:style (merge {:margin  "auto"                 ;; Child


### PR DESCRIPTION
I become *very angry* when I website won't close the modal when I click on the backdrop.
I wouldn't' dare do that to any of my users.

By adding the :backdrop-on-click, using a function to close the modal is trivial.

Ultimately, it should also be possible to close the modal with `esc`. What would be the best way to do that? Adding and removing a listener on `component-did-mount` `component-will-unmount`?