### PR TITLE
Fix ALL backdrop problems   ;-)

### DIFF
--- a/src/re_com/modal_panel.cljs
+++ b/src/re_com/modal_panel.cljs
@@ -30,7 +30,8 @@
                             :left     "0px"
                             :top      "0px"
                             :width    "100%"
-                            :height   "100%"}
+                            :height   "100%"
+                            :z-index   1020}
                            style)}
             attr)
      [:div
@@ -39,13 +40,13 @@
                   :height           "100%"
                   :background-color backdrop-color
                   :opacity          backdrop-opacity
-                  :z-index          1020
+                  :z-index          1
                   :pointer-events   "none"}           ;; TODO: trying to prevent change of focus under the bwhen clicking on backdrop (also with the on-click below). Remove!
        :on-click #(do (println "stopping propagation") (.preventDefault %) (.stopPropagation %))
        }]
      [:div
       {:style (merge {:margin  "auto"                 ;; Child
-                      :z-index 1020}
+                      :z-index 2}
                      (when wrap-nicely? {:background-color "white"
                                          :padding          "16px"
                                          :border-radius    "6px"}))}


### PR DESCRIPTION
This solve the problem mentioned in the doc/demo:

> in certain cases, absolutely positioned components added to the DOM after this component can appear above the backdrop.

As well as #20

See https://code.google.com/p/chromium/issues/detail?id=299913 for more info.

Tested on Firefox and Chromium.