### PR TITLE
Enable the previous month arrow so that you can get to the current mo…

### DIFF
--- a/src/re_com/datepicker.cljs
+++ b/src/re_com/datepicker.cljs
@@ -87,7 +87,7 @@
   "Answer 2 x rows showing month with nav buttons and days NOTE: not internationalized"
   [current {show-weeks? :show-weeks? minimum :minimum maximum :maximum}]
   (let [prev-date     (dec-month @current)
-        prev-enabled? (if minimum (after? prev-date minimum) true)
+        prev-enabled? (if minimum (after? prev-date (dec-month minimum)) true)
         next-date     (inc-month @current)
         next-enabled? (if maximum (before? next-date maximum) true)
         template-row  (if show-weeks? [:tr [:th]] [:tr])]


### PR DESCRIPTION
…nth after moving forward

There's a bug where in the datepicker dropdown you can move forward months, but then are not able to scroll back to the current month. This should fix the off-by-one error in the date dropdown.