### PR TITLE
datepicker-dropdown should deref-or-value model

### DIFF
--- a/src/re_com/datepicker.cljs
+++ b/src/re_com/datepicker.cljs
@@ -232,8 +232,8 @@
     :class     "noselect"
     :min-width "10em"
     :children  [[:label {:class "form-control dropdown-button"}
-                 (if (instance? js/goog.date.Date @model)
-                   (unparse (if (seq format) (formatter format) date-format) @model)
+                 (if (instance? js/goog.date.Date (deref-or-value model))
+                   (unparse (if (seq format) (formatter format) date-format) (deref-or-value model))
                    "")]
                 [:span.dropdown-button.activator.input-group-addon
                  {:style {:padding "3px 0 0 0"}}


### PR DESCRIPTION
`datepicker` supports a `:model` arg which is either a
`goog.date.UtcDateTime` or an atom containing one. `datepicker-dropdown`
claims the same, but calls `anchor-button`, which derefs it: this commit modifies
`anchor-button` so that `datepicker-dropdown` is true to its word.