### PR TITLE
Bug fix of datepicker-dropdown error when nil model

### DIFF
--- a/src/re_com/datepicker.cljs
+++ b/src/re_com/datepicker.cljs
@@ -232,8 +232,8 @@
     :class     "noselect"
     :min-width "10em"
     :children  [[:label {:class "form-control dropdown-button"}
-                 (if (instance? js/goog.date.Date @model)
-                   (unparse (if (seq format) (formatter format) date-format) @model)
+                 (if (instance? js/goog.date.Date (deref-or-value model))
+                   (unparse (if (seq format) (formatter format) date-format) (deref-or-value model))
                    "")]
                 [:span.dropdown-button.activator.input-group-addon
                  {:style {:padding "3px 0 0 0"}}


### PR DESCRIPTION
Fix of Error: No protocol method IDeref.-deref defined for type nul.
Model became optional in one of the previous versions of re-com, but this error arises when not provided to the dropdown version. Seems to work fine with this fix. Thanks!