### PR TITLE
hide the tooltip when a button is disabled

### DIFF
--- a/src/re_com/buttons.cljs
+++ b/src/re_com/buttons.cljs
@@ -46,6 +46,8 @@
                              :on-mouse-out  (handler-fn (reset! showing? false))})
                           attr)
                         label]]
+        (when disabled?
+          (reset! showing? false))
         [box
          :class "display-inline-flex"
          :align :start


### PR DESCRIPTION
- this improves the current behavior which can leave the tooltip
  stranded on the screen
  - but it doesn't allow any tooltip for a disabled button
- a better solution would allow the tooltip to show and hide properly
  even when the button is disabled
- the issue of how to provide a tooltip for a disabled button has had a
  fair amount of discussion online
  - the usual advice is to wrap the button in a div and attach the
    tooltip to that
  - here's a representative discussion:
    https://github.com/angular-ui/bootstrap/issues/1025
  - I've been unable to get this to work for re-com's button, but
    someone with more experience likely could