### PR TITLE
Fix clickable area for month navigation chevron buttons in datepicker

### DIFF
--- a/src/re_com/datepicker.cljs
+++ b/src/re_com/datepicker.cljs
@@ -98,13 +98,13 @@
                  :style {:padding "0px"}
                  :on-click (handler-fn (when prev-enabled? (reset! current prev-date)))}
             [:i.zmdi.zmdi-chevron-left
-             {:style    {:font-size "24px"}}]]
+             {:style {:font-size "24px"}}]]
            [:th {:class "month" :col-span "5"} (month-label @current)]
            [:th {:class (str "next " (if next-enabled? "available selectable" "disabled"))
                  :style {:padding "0px"}
                  :on-click (handler-fn (when next-enabled? (reset! current next-date)))}
             [:i.zmdi.zmdi-chevron-right
-             {:style    {:font-size "24px"}}]])
+             {:style {:font-size "24px"}}]])
      (conj template-row
            [:th {:class "day-enabled"} "SUN"]
            [:th {:class "day-enabled"} "MON"]

--- a/src/re_com/datepicker.cljs
+++ b/src/re_com/datepicker.cljs
@@ -95,16 +95,16 @@
     [:thead
      (conj template-row
            [:th {:class (str "prev " (if prev-enabled? "available selectable" "disabled"))
-                 :style {:padding "0px"}}
+                 :style {:padding "0px"}
+                 :on-click (handler-fn (when prev-enabled? (reset! current prev-date)))}
             [:i.zmdi.zmdi-chevron-left
-             {:style    {:font-size "24px"}
-              :on-click (handler-fn (when prev-enabled? (reset! current prev-date)))}]]
+             {:style    {:font-size "24px"}}]]
            [:th {:class "month" :col-span "5"} (month-label @current)]
            [:th {:class (str "next " (if next-enabled? "available selectable" "disabled"))
-                 :style {:padding "0px"}}
+                 :style {:padding "0px"}
+                 :on-click (handler-fn (when next-enabled? (reset! current next-date)))}
             [:i.zmdi.zmdi-chevron-right
-             {:style    {:font-size "24px"}
-              :on-click (handler-fn (when next-enabled? (reset! current next-date)))}]])
+             {:style    {:font-size "24px"}}]])
      (conj template-row
            [:th {:class "day-enabled"} "SUN"]
            [:th {:class "day-enabled"} "MON"]


### PR DESCRIPTION
Hi,

At the moment, when navigating forwards or backwards for the month in a re-com datepicker, the clickable area is limited to the chevron icon. However, the entire button (th element) has a pointer cursor which means it can be quite confusing when trying to click forwards or backwards but nothing happens due to the cursor not being on the icon. This pull request fixes that problem.