### PR TITLE
Added start-of-week for datepicker

### DIFF
--- a/src/re_com/datepicker.cljs
+++ b/src/re_com/datepicker.cljs
@@ -60,6 +60,24 @@
 (defn- >=date [date1 date2]
   (or (=date date1 date2) (after? date1 date2)))
 
+
+(def ^:private days-vector
+  [{:key :Mo :short-name "M" :name "MON"}
+   {:key :Tu :short-name "T" :name "TUE"}
+   {:key :We :short-name "W" :name "WED"}
+   {:key :Th :short-name "T" :name "THU"}
+   {:key :Fr :short-name "F" :name "FRI"}
+   {:key :Sa :short-name "S" :name "SAT"}
+   {:key :Su :short-name "S" :name "SUN"}])
+
+(defn- rotate
+  [n coll]
+  (let [c (count coll)]
+    (take c (drop (mod n c) (cycle coll)))))
+
+(defn- is-day-pred [d]
+  #(= (day-of-week %) (inc d)))
+
 ;; ----------------------------------------------------------------------------
 
 
@@ -85,7 +103,7 @@
 
 (defn- table-thead
   "Answer 2 x rows showing month with nav buttons and days NOTE: not internationalized"
-  [current {show-weeks? :show-weeks? minimum :minimum maximum :maximum}]
+  [current {show-weeks? :show-weeks? minimum :minimum maximum :maximum start-of-week :start-of-week}]
   (let [prev-date     (dec-month @current)
         ;prev-enabled? (if minimum (after? prev-date (dec-month minimum)) true)
         prev-enabled? (if minimum (after? prev-date minimum) true)
@@ -106,13 +124,8 @@
             [:i.zmdi.zmdi-chevron-right
              {:style {:font-size "24px"}}]])
      (conj template-row
-           [:th {:class "day-enabled"} "SUN"]
-           [:th {:class "day-enabled"} "MON"]
-           [:th {:class "day-enabled"} "TUE"]
-           [:th {:class "day-enabled"} "WED"]
-           [:th {:class "day-enabled"} "THU"]
-           [:th {:class "day-enabled"} "FRI"]
-           [:th {:class "day-enabled"} "SAT"])]))
+           (for [day (rotate start-of-week days-vector)]
+             [:th {:class "day-enabled"} (str (:name day))]))]))
 
 
 (defn- selection-changed
@@ -159,7 +172,7 @@
 (defn- table-tr
   "Return 7 columns of date cells from date inclusive"
   [date focus-month selected attributes disabled? on-change]
-  {:pre [(sunday? date)]}
+;  {:pre [(sunday? date)]}
   (let [table-row (if (:show-weeks? attributes) [:tr (week-td date)] [:tr])
         row-dates (map #(inc-date date %) (range 7))
         today     (if (:show-today? attributes) (:today attributes) nil)]
@@ -169,7 +182,8 @@
 (defn- table-tbody
   "Return matrix of 6 rows x 7 cols table cells representing 41 days from start-date inclusive"
   [current selected attributes disabled? on-change]
-  (let [current-start   (previous sunday? current)
+  (let [start-of-week   (:start-of-week attributes)
+        current-start   (previous (is-day-pred start-of-week) current)
         focus-month     (month current)
         row-start-dates (map #(inc-date current-start (* 7 %)) (range 6))]
     (into [:tbody] (map #(table-tr % focus-month selected attributes disabled? on-change) row-start-dates))))
@@ -192,6 +206,7 @@
    {:name :show-today?   :required false :default false        :type "boolean"                                                :description "when true, today's date is highlighted"}
    {:name :minimum       :required false                       :type "goog.date.UtcDateTime"          :validate-fn goog-date? :description "no selection or navigation before this date"}
    {:name :maximum       :required false                       :type "goog.date.UtcDateTime"          :validate-fn goog-date? :description "no selection or navigation after this date"}
+   {:name :start-of-week :required false :default 0            :type "int"                  :description "weekday thats the first day of week monday = 0, tuesday = 1, etc"}
    {:name :hide-border?  :required false :default false        :type "boolean"                                                :description "when true, the border is not displayed"}
    {:name :class         :required false                       :type "string"                         :validate-fn string?    :description "CSS class names, space separated"}
    {:name :style         :required false                       :type "CSS style map"                  :validate-fn css-style? :description "CSS styles to add or override"}

--- a/src/re_demo/core.cljs
+++ b/src/re_demo/core.cljs
@@ -165,7 +165,7 @@
 
 (def id-store        (local-storage (atom nil) ::id-store))
 (def selected-tab-id (reagent/atom (if (or (nil? @id-store) (nil? (item-for-id @id-store tabs-definition)))
-                                     (:id date(first tabs-definition))
+                                     (:id (first tabs-definition))
                                      @id-store)))  ;; id of the selected tab from local storage
 
 (defroute demo-page "/:tab" [tab] (let [id (keyword tab)]

--- a/src/re_demo/core.cljs
+++ b/src/re_demo/core.cljs
@@ -165,7 +165,7 @@
 
 (def id-store        (local-storage (atom nil) ::id-store))
 (def selected-tab-id (reagent/atom (if (or (nil? @id-store) (nil? (item-for-id @id-store tabs-definition)))
-                                     :date ;(:id date(first tabs-definition))
+                                     (:id date(first tabs-definition))
                                      @id-store)))  ;; id of the selected tab from local storage
 
 (defroute demo-page "/:tab" [tab] (let [id (keyword tab)]

--- a/src/re_demo/core.cljs
+++ b/src/re_demo/core.cljs
@@ -165,7 +165,7 @@
 
 (def id-store        (local-storage (atom nil) ::id-store))
 (def selected-tab-id (reagent/atom (if (or (nil? @id-store) (nil? (item-for-id @id-store tabs-definition)))
-                                     :date ;(:id date(first tabs-definition))
+                                     (:id (first tabs-definition))
                                      @id-store)))  ;; id of the selected tab from local storage
 
 (defroute demo-page "/:tab" [tab] (let [id (keyword tab)]

--- a/src/re_demo/core.cljs
+++ b/src/re_demo/core.cljs
@@ -165,7 +165,7 @@
 
 (def id-store        (local-storage (atom nil) ::id-store))
 (def selected-tab-id (reagent/atom (if (or (nil? @id-store) (nil? (item-for-id @id-store tabs-definition)))
-                                     (:id (first tabs-definition))
+                                     :date ;(:id date(first tabs-definition))
                                      @id-store)))  ;; id of the selected tab from local storage
 
 (defroute demo-page "/:tab" [tab] (let [id (keyword tab)]

--- a/src/re_demo/datepicker.cljs
+++ b/src/re_demo/datepicker.cljs
@@ -104,6 +104,7 @@
                                   :gap      "5px"
                                   :children [[label :style label-style :label ":minimum or :maximum not specified"]
                                              [datepicker
+                                              :start-of-week 0
                                               :model         model1
                                               :disabled?     disabled?
                                               :show-today?   @show-today?
@@ -117,6 +118,7 @@
                                   :gap      "5px"
                                   :children [[label :style label-style :label ":minimum \"20140831\" :maximum \"20141019\""]
                                              [datepicker
+                                              :start-of-week 3
                                               :model         model2
                                               :minimum       (iso8601->date "20140831")
                                               :maximum       (iso8601->date "20141019")

--- a/src/re_demo/datepicker.cljs
+++ b/src/re_demo/datepicker.cljs
@@ -104,7 +104,6 @@
                                   :gap      "5px"
                                   :children [[label :style label-style :label ":minimum or :maximum not specified"]
                                              [datepicker
-                                              :start-of-week 0
                                               :model         model1
                                               :disabled?     disabled?
                                               :show-today?   @show-today?
@@ -118,7 +117,6 @@
                                   :gap      "5px"
                                   :children [[label :style label-style :label ":minimum \"20140831\" :maximum \"20141019\""]
                                              [datepicker
-                                              :start-of-week 3
                                               :model         model2
                                               :minimum       (iso8601->date "20140831")
                                               :maximum       (iso8601->date "20141019")


### PR DESCRIPTION
For internationalization purposes, this is a simple way to change the start of week. 
Per ISO standards, I've defined Monday as 0 and Sunday as 6, and put 0 as default.