### PR TITLE
Decouple label from rendering function in dropdown.

### DIFF
--- a/src/re_com/dropdown.cljs
+++ b/src/re_com/dropdown.cljs
@@ -41,7 +41,7 @@
   (let [lower-filter-text (string/lower-case filter-text)
         filter-fn         (fn [opt]
                             (let [group (if (nil? (group-fn opt)) "" (group-fn opt))
-                                  label (str (label-fn opt))] ;; Need str for non-string labels like hiccup
+                                  label (str (label-fn opt))] ;; TODO: remove str? we should be able to assume label-fn returns a string.
                               (or
                                 (>= (.indexOf (string/lower-case group) lower-filter-text) 0)
                                 (>= (.indexOf (string/lower-case label) lower-filter-text) 0))))]
@@ -123,10 +123,10 @@
 
 
 (defn make-choice-item
-  [id-fn label-fn callback internal-model opt]
+  [id-fn render-fn callback internal-model opt]
   (let [id (id-fn opt)
-        label (label-fn opt)]
-    ^{:key (str id)} [choice-item id label callback internal-model]))
+        markup (render-fn opt)]
+    ^{:key (str id)} [choice-item id markup callback internal-model]))
 
 
 (defn- filter-text-box-base
@@ -195,8 +195,9 @@
    {:name :model         :required true                   :type "the id of a choice | atom"                                    :description [:span "the id of the selected choice. If nil, " [:code ":placeholder"] " text is shown"]}
    {:name :on-change     :required true                   :type "id -> nil"                     :validate-fn fn?               :description [:span "called when a new choice is selected. Passed the id of new choice"] }
    {:name :id-fn         :required false :default :id     :type "choice -> anything"            :validate-fn ifn?              :description [:span "given an element of " [:code ":choices"] ", returns its unique identifier (aka id)"]}
-   {:name :label-fn      :required false :default :label  :type "choice -> string | hiccup"     :validate-fn ifn?              :description [:span "given an element of " [:code ":choices"] ", returns its displayable label"]}
+   {:name :label-fn      :required false :default :label  :type "choice -> string"              :validate-fn ifn?              :description [:span "given an element of " [:code ":choices"] ", returns its displayable label."]}
    {:name :group-fn      :required false :default :group  :type "choice -> anything"            :validate-fn ifn?              :description [:span "given an element of " [:code ":choices"] ", returns its group identifier"]}
+   {:name :render-fn     :required false                  :type "choice -> string | hiccup"     :validate-fn ifn?              :description [:span "given an element of " [:code ":choices"] ", returns the markup that will be rendered for that choice. Defaults to the label if no custom markup is required."]}
    {:name :disabled?     :required false :default false   :type "boolean | atom"                                               :description "if true, no user selection is allowed"}
    {:name :filter-box?   :required false :default false   :type "boolean"                                                      :description "if true, a filter text field is placed at the top of the dropdown"}
    {:name :regex-filter? :required false :default false   :type "boolean | atom"                                               :description "if true, the filter text field will support JavaScript regular expressions. If false, just plain text"}
@@ -220,8 +221,8 @@
         internal-model (reagent/atom @external-model)         ;; Create a new atom from the model to be used internally
         drop-showing?  (reagent/atom false)
         filter-text    (reagent/atom "")]
-    (fn [& {:keys [choices model on-change disabled? filter-box? regex-filter? placeholder width max-height tab-index id-fn label-fn group-fn class style attr]
-            :or {id-fn :id label-fn :label group-fn :group}
+    (fn [& {:keys [choices model on-change disabled? filter-box? regex-filter? placeholder width max-height tab-index id-fn label-fn group-fn render-fn class style attr]
+            :or {id-fn :id label-fn :label group-fn :group render-fn label-fn}
             :as args}]
       {:pre [(validate-args-macro single-dropdown-args-desc args "single-dropdown")]}
       (let [choices          (deref-or-value choices)
@@ -307,7 +308,7 @@
              (when max-height {:style {:max-height max-height}})
              (if (-> filtered-choices count pos?)
                (let [[group-names group-opt-lists] (choices-with-group-headings filtered-choices group-fn)
-                     make-a-choice                 (partial make-choice-item id-fn label-fn callback internal-model)
+                     make-a-choice                 (partial make-choice-item id-fn render-fn callback internal-model)
                      make-choices                  #(map make-a-choice %1)
                      make-h-then-choices           (fn [h opts]
                                                      (cons (make-group-heading h)

--- a/src/re_demo/dropdowns.cljs
+++ b/src/re_demo/dropdowns.cljs
@@ -12,7 +12,8 @@
             ;{:id 4 :label "Use of :id-fn etc."} ;; for testing
             {:id 5 :label "Keyboard support"}
             {:id 6 :label "Other parameters"}
-            {:id 7 :label "Two dependent dropdowns"}])
+            {:id 7 :label "Two dependent dropdowns"}
+            {:id 8 :label "Custom markup"}])
 
 
 (def countries [{:id "au" :label "Australia"}
@@ -57,7 +58,7 @@
                         {:id "US" :label "United States"            :group "EN Speakers"}
                         {:id "GB" :label "United Kingdom"           :group "EN Speakers"}
                         {:id "E1" :label "Iraq"                     :group "Updated Axis Of Evil"}
-                        {:id "E2" :label [:strong "New Zealand"]    :group "Updated Axis Of Evil"}
+                        {:id "E2" :label "New Zealand"              :group "Updated Axis Of Evil"}
                         {:id "E3" :label "Iran"                     :group "Updated Axis Of Evil"}
                         {:id "E4" :label "North Korea"              :group "Updated Axis Of Evil"}
                         {:id "03" :label "Afghanistan"              :group "'A' COUNTRIES"}
@@ -120,7 +121,6 @@
                   [p "This feature is triggered if any choice has a :group attribute. Typically all choices will have a :group or none will. It's up to you to ensure that choices with the same :group are adjacent in the vector."]
                   [p "Because :model is initially nil, the :placeholder text is initially displayed."]
                   [p ":max-width is set here to make the dropdown taller."]
-                  [p ":label can be a string or arbitrary markup. Notice the boldness of the 'New Zealand'."]
                   [h-box
                    :gap      "10px"
                    :align    :center
@@ -333,6 +333,31 @@
                                  "None"
                                  (str (:label (item-for-id @selected-city-id cities)) " [" @selected-city-id "]"))]]]]])))
 
+(defn demo8
+  []
+  (let [selected-country-id (reagent/atom nil)]
+    (fn []
+      [v-box
+       :gap      "10px"
+       :children [[p "Dropdowns choices can be built with arbitrary markup using the :render-fn attribute. When filtering, only the text from the label will be considered."]
+                  [h-box
+                   :gap      "10px"
+                   :align    :center
+                   :children [[single-dropdown
+                               :choices     countries
+                               :render-fn   (fn [choice] [:div [:span (:label choice)]
+                                                               [:span {:style {:float "right"}} "\u2691"]])
+                               :model       selected-country-id
+                               :placeholder "Choose a country"
+                               :width       "300px"
+                               :max-height  "400px"
+                               :filter-box? false
+                               :on-change   #(reset! selected-country-id %)]
+                              [:div
+                               [:strong "Selected country: "]
+                               (if (nil? @selected-country-id)
+                                 "None"
+                                 (str (:label (item-for-id @selected-country-id grouped-countries)) " [" @selected-country-id "]"))]]]]])))
 
 (defn panel2
   []
@@ -387,7 +412,8 @@
                                              4 [demo4] ;; for testing - uncomment equivalent line in demos vector above
                                              5 [demo5]
                                              6 [demo6]
-                                             7 [demo7])]]]]]])))
+                                             7 [demo7]
+                                             8 [demo8])]]]]]])))
 
 
 ;; core holds a reference to panel, so need one level of indirection to get figwheel updates


### PR DESCRIPTION
This allows to provide custom markup while not messing with filtering. See #107.