### PR TITLE
fix missing core.async dependency error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
   :dependencies     [[org.clojure/clojure         "1.8.0"]
                      [org.clojure/clojurescript   "1.9.89"]
                      [reagent                     "0.6.0"]
+                     [org.clojure/core.async "0.2.391"]
                      [com.andrewmcveigh/cljs-time "0.4.0"]] ;; TODO: Bump this to 0.5.0 as soon as it's available (https://github.com/Day8/re-com/pull/98/files)
 
   ;:plugins          [[lein-unpack-resources "0.1.1"]]
@@ -28,7 +29,7 @@
   ;                    :extract-path "run/resources-frame"}]
 
   :profiles         {:dev       {:dependencies [[clj-stacktrace                  "0.2.8"]
-                                                [alandipert/storage-atom         "2.0.1" ]
+                                                [alandipert/storage-atom         "2.0.1"]
                                                 [com.cognitect/transit-cljs      "0.8.239"] ;; Overrides version in storage-atom which prevents compiler warnings about uuid? and boolean? being replaced
                                                 [figwheel                        "0.5.7"]
                                                 [secretary                       "1.2.3"]]
@@ -151,5 +152,5 @@
 
                      "test-auto"  ["with-profile" "+dev-test" "do"
                                    ["test-once"]
-                                   ["cljsbuild" "auto" "test"]]}
-  )
+                                   ["cljsbuild" "auto" "test"]]})
+


### PR DESCRIPTION
Seeing this error when I include re-com `0.9.0` into my other project and try to 
build for prod with:

`lein clean && lein cljsbuild once min`

> Caused by: clojure.lang.ExceptionInfo: No such namespace: cljs.core.async, could not locate cljs/core/async.cljs, cljs/core/async.cljc, or Closure namespace "cljs.core.async" in file /home/travis/build/dviramontes/cfd-fn-talk/target/cljsbuild-compiler-1/re_com/typeahead.cljs {:tag :cljs/analysis-error}

You can see the full stack trace here:
https://travis-ci.org/dviramontes/cfd-fn-talk/builds/160884593

This fixed it for me but perhaps there is another way to solve it? 

Thanks!
