### PR TITLE
Bug-fix for new reagent 0.6.0

### DIFF
--- a/src/re_com/selection_list.cljs
+++ b/src/re_com/selection_list.cljs
@@ -41,7 +41,7 @@
      :attr {:on-click (handler-fn (when-not disabled?
                                     (on-change (check-clicked selections item-id (not (selections item-id)) required?))))}
      :child [checkbox
-             :model (selections item-id)
+             :model (some? (selections item-id))
              :on-change #()                                 ;; handled by enclosing box
              :disabled? disabled?
              :label-style (label-style (selections item-id) as-exclusions?)


### PR DESCRIPTION
Now `true` or `false` is passed to checkbox rather than `nil` or `item-id`