### PR TITLE
multi-select with option map

### DIFF
--- a/run/resources/public/assets/css/re-com.css
+++ b/run/resources/public/assets/css/re-com.css
@@ -1340,6 +1340,38 @@ code {
 }
 
 
+/* multi-complete styles */
+
+.multi-complete {
+  display:inline-block;
+  border: 0.3px solid grey;
+  padding:4px 4px 0 0;
+  cursor:text;
+}
+
+.multi-complete-input {
+  display:inline-block;
+  width:10em;
+  margin:0 0 4px;
+  padding:4px 6px;
+  background:none;
+  border: 0;
+  outline:0;
+  font:inherit;
+  color:inherit;
+  text-align:left;
+  text-shadow:none;
+}
+
+.multi-complete-output {
+  display:inline-block;
+  margin-left:4px;
+}
+
+.multi-complete-highlight {
+    background-color: #ccc;
+}
+
 /*----------------------------------------------------------------------------------------
   Only required for re-demo
 ----------------------------------------------------------------------------------------*/

--- a/src/re_com/multi_complete.cljs
+++ b/src/re_com/multi_complete.cljs
@@ -1,0 +1,138 @@
+(ns re-com.multi-complete
+  (:require [reagent.core :as r]
+            [re-com.box      :refer [box border h-box v-box]]
+            [clojure.string :as str]
+            [re-com.core :as rc]
+            [cljs.spec :as s]))
+
+
+
+(def multi-complete-args-des
+  [{:name :model
+    :type "vector of strings | atom"
+    :validate-fn vector?
+    :description "a vector with all the selected items -- kept in order so that on-delete can remove them appropriately"
+    }
+   {:name :suggestions
+    :type "vector of strings"
+    :validate-fn vector?
+    :description "All of your choices"
+    }
+   {:name :highlight-class
+    :type "string"
+    :validate-fn string?
+    :description "class for selected item within suggestion dropdown"}
+   {:name :item-class
+    :type "string"
+    :validate-fn string?
+    :description "class for each item in suggestion dropdown"}
+   {:name :save!
+    :type "choice -> anything"
+    :validate-fn ifn?
+    :description "a callback that will be passed either a selected item from suggestions or the value of the text in the input field"
+    }
+    {:name :on-delete!
+     :type "nil -> anything"
+     :validate-fn ifn?
+     :description "Fired whenever the text field is empty and delete button is pressed, purpose is generally to remove the last item in the model/selections atom"}
+   {:name :placeholder
+    :type "string"
+    :description "A hint to make sure users know they can type here"}]
+  )
+
+
+
+
+(defn multi-complete [{:keys [highlight-class
+                              placeholder
+                              item-class
+                              list-class
+                              suggestions
+                              save!
+                              selections
+                              on-delete]
+                       :or {highlight-class "multi-complete-highlight"
+                            item-class ""}}]
+  (let [a (r/atom "")
+        selected-index (r/atom -1)
+        typeahead-hidden? (r/atom false)
+        mouse-on-list? (r/atom false)]
+    (fn []
+      (let [options  (if (clojure.string/blank? @a)
+                       []
+                       (filter
+                        #(-> % (.toLowerCase %) (.indexOf (.toLowerCase @a)) (> -1))
+                        suggestions))
+            matching-options (filter (comp not (set @selections)) options)
+            choose-selected #(if (and (not-empty matching-options)
+                                       (> @selected-index -1))
+                              (let [choice (nth matching-options @selected-index)]
+                                (save! choice)
+                                (reset! selected-index 0)
+                                (reset! a ""))
+                              (when (not (str/blank? @a))
+                                (do
+                                  (save! @a)
+                                  (reset! selected-index 0)
+                                  (reset! a ""))))]
+        [h-box
+         :class "multi-complete"
+         :children [[:div.multi-complete-output
+                     (when @selections
+                       (for [x @selections]
+                         ^{:key x}[:button {:class "btn btn-default"
+                                          :on-click #(swap! selections (fn [y] (remove #{x} y)))}(str x)]
+                         ))
+                     [:input.multi-complete-input
+                      {:value @a
+                       :placeholder placeholder
+                       :on-change #(reset! a (-> % .-target .-value))
+                       :on-key-down #(do
+                                       (case (.-which %)
+                                         38 (do
+                                              (.preventDefault %)
+                                              (when-not (= @selected-index -1)
+                                                (swap! selected-index dec)))
+                                         40 (do
+                                              (.preventDefault %)
+                                              (when-not (= @selected-index (dec (count matching-options)))
+                                                (swap! selected-index inc)))
+                                         9  (choose-selected)
+                                         13 (choose-selected)
+                                         8  (when (clojure.string/blank? @a)
+                                              (on-delete))
+                                         27 (do #_(reset! typeahead-hidden? true)
+                                                (reset! selected-index -1))
+                                         "default"))}]
+
+                     [:ul {:style
+                           {:display (if (or (empty? matching-options) @typeahead-hidden?) :none :block) }
+                           :class list-class
+                           :on-mouse-enter #(reset! mouse-on-list? true)
+                           :on-mouse-leave #(reset! mouse-on-list? false)}
+                      (doall
+                       (map-indexed
+                        (fn [index result]
+                          [:li {:tab-index     index
+                                :key           index
+                                :class         (if (= @selected-index index) highlight-class item-class)
+                                :on-mouse-over #(do
+                                                  (reset! selected-index (js/parseInt (.getAttribute (.-target %) "tabIndex"))))
+                                :on-click      #(do
+                                                  (reset! a "")
+                                                  (save! result)
+                                                  )}
+                           result])
+                        matching-options))]]]]
+        ))))
+
+
+
+  ;; (defcard-rg tags-example
+  ;;   (let [selections (r/atom [])]
+  ;;     [multi-complete {:highlight-class "highlight"
+  ;;                      :selections selections
+  ;;                      :on-delete #(swap! selections pop)
+  ;;                      :save! #(swap! selections conj %) 
+  ;;                      :suggestions ["Reagent""Re-frame""Re-com""Reaction"]}])
+  ;;   ))

--- a/src/re_com/selection_list.cljs
+++ b/src/re_com/selection_list.cljs
@@ -93,12 +93,35 @@
 
 
 (def selection-list-args-desc
-  [{:name :choices        :required true                  :type "vector of choices | atom"           :validate-fn vector-of-maps? :description [:span "the selectable items. Elements can be strings or more interesting data items like {:label \"some name\" :sort 5}. Also see " [:code ":label-fn"] " below (list of maps also allowed)"]}
-   {:name :model          :required true                  :type "set of :ids within :choices | atom" :validate-fn set-or-atom?    :description "the currently selected items. Note: items are considered distinct"}
-   {:name :on-change      :required true                  :type "set of :ids -> nil | atom"          :validate-fn fn?             :description [:span "a callback which will be passed set of the ids (as defined by " [:code ":id-fn"] ") of the selected items"]}
-   {:name :id-fn          :required false :default :id    :type "choice -> anything"                 :validate-fn ifn?            :description [:span "given an element of " [:code ":choices"] ", returns its unique identifier (aka id)"]}
-   {:name :label-fn       :required false :default :label :type "choice -> anything"                 :validate-fn ifn?            :description [:span "given an element of " [:code ":choices"] ", returns its displayable label"]}
-   {:name :multi-select?  :required false :default true   :type "boolean | atom"                                                  :description "when true, use check boxes, otherwise radio buttons"}
+  [{:name :choices        :required true
+    :type "vector of choices | atom"
+    :validate-fn vector-of-maps?
+    :description [:span "the selectable items. Elements can be strings or more interesting data items like {:label \"some name\" :sort 5}. Also see " [:code ":label-fn"] " below (list of maps also allowed)"]}
+   {:name :model
+    :required true
+    :type "set of :ids within :choices | atom"
+    :validate-fn set-or-atom?
+    :description "the currently selected items. Note: items are considered distinct"}
+   {:name :on-change
+    :required true
+    :type "set of :ids -> nil | atom"
+    :validate-fn fn?
+    :description [:span "a callback which will be passed set of the ids (as defined by " [:code ":id-fn"] ") of the selected items"]}
+   {:name :id-fn
+    :required false
+    :default :id
+    :type "choice -> anything"
+    :validate-fn ifn?
+    :description [:span "given an element of " [:code ":choices"] ", returns its unique identifier (aka id)"]}
+   {:name :label-fn
+    :required false
+    :default :label
+    :type "choice -> anything"
+    :validate-fn ifn?            :description [:span "given an element of " [:code ":choices"] ", returns its displayable label"]}
+   {:name :multi-select?
+    :required false
+    :default true
+    :type "boolean | atom"                                                  :description "when true, use check boxes, otherwise radio buttons"}
    {:name :as-exclusions? :required false :default false  :type "boolean | atom"                                                  :description "when true, selected items are shown with struck-out labels"}
    {:name :required?      :required false :default false  :type "boolean | atom"                                                  :description "when true, at least one item must be selected. Note: being able to un-select a radio button is not a common use case, so this should probably be set to true when in single select mode"}
    {:name :width          :required false                 :type "string | atom"                      :validate-fn string-or-atom? :description "a CSS style e.g. \"250px\". When specified, item labels may be clipped. Otherwise based on widest label"}

--- a/src/re_demo/core.cljs
+++ b/src/re_demo/core.cljs
@@ -43,7 +43,9 @@
             [re-demo.line                  :as    line]
             [re-demo.scroller              :as    scroller]
             [re-demo.border                :as    border]
+            [re-demo.multi-complete                :as    multi-complete]
             [re-demo.typeahead             :as    typeahead]
+            
             [goog.history.EventType        :as    EventType])
   (:import [goog History]))
 
@@ -73,6 +75,7 @@
 
    {:id :selection              :level :major :label "Selection"}
    {:id :dropdown               :level :minor :label "Dropdowns"          :panel dropdowns/panel}
+   {:id :multi-complete                 :level :minor :label "Multi-Complete"     :panel multi-complete/panel}
    {:id :lists                  :level :minor :label "Selection List"     :panel selection-list/panel}
    {:id :tabs                   :level :minor :label "Tabs"               :panel tabs/panel}
    {:id :typeahead              :level :minor :label "Typeahead"          :panel typeahead/panel}

--- a/src/re_demo/multi_complete.cljs
+++ b/src/re_demo/multi_complete.cljs
@@ -1,0 +1,20 @@
+(ns re-demo.multi-complete
+  (:require [reagent.core :as r]
+            [re-com.multi-complete :refer [multi-complete]]
+            [re-com.box      :refer [box border h-box v-box]]
+            [re-com.core :as rc]
+            ))
+
+
+
+
+(defn panel []
+    (let [selections (r/atom [])]
+      [multi-complete {:highlight-class "multi-complete-highlight"
+                       :selections selections
+                       :on-delete #(swap! selections pop)
+                       :save! #(swap! selections conj %)
+                       :suggestions ["Reagent""Re-frame""Re-com""Reaction"]}])
+    )
+
+


### PR DESCRIPTION
Submitting a component for chosen style multi-complete with typeahead.  It doesn't yet totally match the look and feel of all the other re-com components, and in this implementation it accepts all the options as a map -- rather than the re-com style of validating arguments separately. 

See example here
https://github.com/Day8/re-com/issues/115

In my use case I wanted users to be able to submit new options, so that is the default behavior, I imagine that that might be an option that could be disabled. 

I'll be offline for the next few weeks, but figured if someone else had interest they could convert it from using an options map to following the re-com format.  Otherwise, very open to suggestions about what the options the component should accept, and can complete the conversion later.
