### PR TITLE
Typeahead dropdown list doesn't shift content underneath anymore (abs…

### DIFF
--- a/run/resources/public/assets/css/re-com.css
+++ b/run/resources/public/assets/css/re-com.css
@@ -1327,6 +1327,8 @@ code {
 }
 
 .rc-typeahead-suggestions-container {
+    position: absolute;
+    width: 100%;
     background-color: #eee;
 }
 

--- a/src/re_com/typeahead.cljs
+++ b/src/re_com/typeahead.cljs
@@ -282,21 +282,22 @@
            :change-on-blur? false
            :attr {:on-key-down (partial input-text-on-key-down! state-atom)}]
           (if (or (not-empty suggestions) waiting?)
-            [v-box
-             :class "rc-typeahead-suggestions-container"
-             :children [(when waiting?
-                          [box :align :center :child [throbber :size :small :class "rc-typeahead-throbber"]])
-                        (for [[ i s ] (map vector (range) suggestions)
-                              :let [selected? (= suggestion-active-index i)]]
-                          ^{:key i}
-                          [box
-                           :child (if render-suggestion
-                                    (render-suggestion s)
-                                    s)
-                           :class (str "rc-typeahead-suggestion"
-                                       (when selected? " active"))
-                           :attr {:on-mouse-over #(swap! state-atom activate-suggestion-by-index i)
-                                  :on-mouse-down #(do (.preventDefault %) (swap! state-atom choose-suggestion-by-index i))}])]])]]))))
+            [:div {:style {:position "relative"}}
+             [v-box
+              :class "rc-typeahead-suggestions-container"
+              :children [(when waiting?
+                           [box :align :center :child [throbber :size :small :class "rc-typeahead-throbber"]])
+                         (for [[i s] (map vector (range) suggestions)
+                               :let [selected? (= suggestion-active-index i)]]
+                           ^{:key i}
+                           [box
+                            :child (if render-suggestion
+                                     (render-suggestion s)
+                                     s)
+                            :class (str "rc-typeahead-suggestion"
+                                        (when selected? " active"))
+                            :attr {:on-mouse-over #(swap! state-atom activate-suggestion-by-index i)
+                                   :on-mouse-down #(do (.preventDefault %) (swap! state-atom choose-suggestion-by-index i))}])]]])]]))))
 
 (defn- debounce
   "Return a channel which will receive a value from the `in` channel only

--- a/src/re_demo/typeahead.cljs
+++ b/src/re_demo/typeahead.cljs
@@ -93,7 +93,8 @@
                                                                    :on-change        #(reset! typeahead-on-change-value %)
                                                                    :change-on-blur?  change-on-blur?
                                                                    :rigid?           rigid?
-                                                                   :disabled?        disabled?]]]
+                                                                   :disabled?        disabled?]
+                                                                  [label :label "[underneath]"]]]
                                                       [v-box
                                                        :gap      "15px"
                                                        :children [[title :level :level3 :label "Callbacks"]


### PR DESCRIPTION
…olute position)

Dropdown is now wrapped in `position:relative` div and is `position:absolute` itself so shouldn't shift content underneath. Moreover if input is restyled to have smaller height list should adjust naturally.

Not sure if setting style for wrapping div inside cljs (not css) is a good idea but this thing is small and shouldn't be customizable thus brings no harm i uppose.