### PR TITLE
Add support of reactive :minimum and :maximum to datepicker.

### DIFF
--- a/src/re_com/datepicker.cljs
+++ b/src/re_com/datepicker.cljs
@@ -105,6 +105,8 @@
   "Answer 2 x rows showing month with nav buttons and days NOTE: not internationalized"
   [display-month {show-weeks? :show-weeks? minimum :minimum maximum :maximum start-of-week :start-of-week}]
   (let [prev-date     (dec-month @display-month)
+        minimum       (deref-or-value minimum)
+        maximum       (deref-or-value maximum)
         ;prev-enabled? (if minimum (after? prev-date (dec-month minimum)) true)
         prev-enabled? (if minimum (after? prev-date minimum) true)
         next-date     (inc-month @display-month)
@@ -136,7 +138,9 @@
 (defn- table-td
   [date focus-month selected today {minimum :minimum maximum :maximum :as attributes} disabled? on-change]
   ;;following can be simplified and terse
-  (let [enabled-min   (if minimum (>=date date minimum) true)
+  (let [minimum       (deref-or-value minimum)
+        maximum       (deref-or-value maximum)
+        enabled-min   (if minimum (>=date date minimum) true)
         enabled-max   (if maximum (<=date date maximum) true)
         enabled-day   (and enabled-min enabled-max)
         disabled-day? (if enabled-day
@@ -193,8 +197,8 @@
    {:name :selectable-fn :required false :default "(fn [date] true)" :type "pred"                           :validate-fn fn?        :description "Predicate is passed a date. If it answers false, day will be shown disabled and can't be selected."}
    {:name :show-weeks?   :required false :default false              :type "boolean"                                                :description "when true, week numbers are shown to the left"}
    {:name :show-today?   :required false :default false              :type "boolean"                                                :description "when true, today's date is highlighted"}
-   {:name :minimum       :required false                             :type "goog.date.UtcDateTime"          :validate-fn goog-date? :description "no selection or navigation before this date"}
-   {:name :maximum       :required false                             :type "goog.date.UtcDateTime"          :validate-fn goog-date? :description "no selection or navigation after this date"}
+   {:name :minimum       :required false                             :type "goog.date.UtcDateTime | atom"   :validate-fn goog-date? :description "no selection or navigation before this date"}
+   {:name :maximum       :required false                             :type "goog.date.UtcDateTime | atom"   :validate-fn goog-date? :description "no selection or navigation after this date"}
    {:name :start-of-week :required false :default 6                  :type "int"                                                    :description "first day of week (Monday = 0 ... Sunday = 6)"}
    {:name :hide-border?  :required false :default false              :type "boolean"                                                :description "when true, the border is not displayed"}
    {:name :class         :required false                             :type "string"                         :validate-fn string?    :description "CSS class names, space separated"}

--- a/src/re_com/datepicker.cljs
+++ b/src/re_com/datepicker.cljs
@@ -107,8 +107,7 @@
   (let [prev-date     (dec-month @display-month)
         minimum       (deref-or-value minimum)
         maximum       (deref-or-value maximum)
-        ;prev-enabled? (if minimum (after? prev-date (dec-month minimum)) true)
-        prev-enabled? (if minimum (after? prev-date minimum) true)
+        prev-enabled? (if minimum (after? prev-date (dec-month minimum)) true)
         next-date     (inc-month @display-month)
         next-enabled? (if maximum (before? next-date maximum) true)
         template-row  (if show-weeks? [:tr [:th]] [:tr])]

--- a/src/re_demo/datepicker.cljs
+++ b/src/re_demo/datepicker.cljs
@@ -83,8 +83,8 @@
 
 (defn- show-variant
   [variation]
-  (let [model1          (reagent/atom (minus (now) (days 3)))
-        model2          (reagent/atom (plus  (now) (days 10)))
+  (let [model1          (reagent/atom (now))
+        model2          (reagent/atom (plus  (now) (days 120)))
         disabled?       (reagent/atom false)
         show-today?     (reagent/atom true)
         show-weeks?     (reagent/atom false)

--- a/src/re_demo/datepicker.cljs
+++ b/src/re_demo/datepicker.cljs
@@ -3,7 +3,8 @@
     [goog.date.Date]
     [reagent.core      :as    reagent]
     [reagent.ratom     :refer-macros [reaction]]
-    [cljs-time.core    :refer [now days minus plus day-of-week]]
+    [cljs-time.core    :refer [now days minus plus day-of-week before?]]
+    [cljs-time.coerce  :refer [to-local-date]]
     [cljs-time.format  :refer [formatter unparse]]
     [re-com.core       :refer [h-box v-box box gap single-dropdown datepicker datepicker-dropdown checkbox label title p md-icon-button]]
     [re-com.datepicker :refer [iso8601->date datepicker-dropdown-args-desc]]
@@ -21,7 +22,6 @@
           (if (contains? @set-atom member)
             (disj @set-atom member)
             (conj @set-atom member))))
-
 
 (defn- checkbox-for-day
   [day enabled-days]
@@ -84,7 +84,7 @@
 (defn- show-variant
   [variation]
   (let [model1          (reagent/atom (minus (now) (days 3)))
-        model2          (reagent/atom (iso8601->date "20140914"))
+        model2          (reagent/atom (plus  (now) (days 10)))
         disabled?       (reagent/atom false)
         show-today?     (reagent/atom true)
         show-weeks?     (reagent/atom false)
@@ -101,9 +101,12 @@
                    :align    :start
                    :children [[v-box
                                :gap      "5px"
-                               :children [[label :style label-style :label ":minimum or :maximum not specified"]
+                               :children [[label
+                                           :style label-style
+                                           :label (str " :maximum " (date->string @model2))]
                                           [datepicker
                                            :model         model1
+                                           :maximum       model2
                                            :disabled?     disabled?
                                            :show-today?   @show-today?
                                            :show-weeks?   @show-weeks?
@@ -121,16 +124,19 @@
                                                       [md-icon-button
                                                        :md-icon-name "zmdi-arrow-right"
                                                        :size         :smaller
+                                                       :disabled?    (not (before? (to-local-date @model1)
+                                                                                   (to-local-date @model2)))
                                                        :on-click     #(reset! model1 (plus @model1 (days 1)))]]]]]
-                              ;; restricted to both minimum & maximum date
+
                               [v-box
                                :gap      "5px"
-                               :children [[label :style label-style :label ":minimum \"20140831\" :maximum \"20141019\", :start-of-week Monday"]
+                               :children [[label
+                                           :style label-style
+                                           :label (str ":minimum " (date->string @model1) ", :start-of-week Monday")]
                                           [datepicker
                                            :start-of-week 0
                                            :model         model2
-                                           :minimum       (iso8601->date "20140831")
-                                           :maximum       (iso8601->date "20141019")
+                                           :minimum       model1
                                            :show-today?   @show-today?
                                            :show-weeks?   @show-weeks?
                                            :selectable-fn selectable-pred


### PR DESCRIPTION
This PR adds support of `ratoms` to `:minimum` and `:maximum` properties of `datepicker` component.

This simplifies creation of date range selection components (where start date cannot be greater than end date), like this:

```clojure
(def start-date (r/atom (now)))
(def end-date   (r/atom (plus (now) (days 42))))

(defn mount-root
  []
  (r/render [ui/h-box
             :gap "10px"
             :children [[ui/datepicker-dropdown
                         :maximum   end-date
                         :model     start-date
                         :on-change #(reset! start-date %)]
                        [ui/datepicker-dropdown
                         :minimum   start-date
                         :model     end-date
                         :on-change #(reset! end-date %)]]]
            (.getElementById js/document "app-host")))
```

Both `:minimum` and `:maximum` can be values or ratoms.

I updated demo application as well: inline date pickers now behave as a date range selection component.