### PR TITLE
Add :placeholder option for datepicker dropdown

### DIFF
--- a/src/re_com/datepicker.cljs
+++ b/src/re_com/datepicker.cljs
@@ -240,7 +240,7 @@
 
 (defn- anchor-button
   "Provide clickable field with current date label and dropdown button e.g. [ 2014 Sep 17 | # ]"
-  [shown? model format]
+  [shown? model format placeholder]
   [:div {:class    "rc-datepicker-dropdown-anchor input-group display-flex noselect"
          :style    (flex-child-style "none")
          :on-click (handler-fn (swap! shown? not))}
@@ -251,15 +251,16 @@
     :children  [[:label {:class "form-control dropdown-button"}
                  (if (instance? js/goog.date.Date (deref-or-value model))
                    (unparse (if (seq format) (formatter format) date-format) (deref-or-value model))
-                   "")]
+                   [:span {:style {:color "#999999"}} placeholder])]
                 [:span.dropdown-button.activator.input-group-addon
                  {:style {:padding "3px 0px 0px 0px"}}
                  [:i.zmdi.zmdi-apps {:style {:font-size "24px"}}]]]]])
 
 (def datepicker-dropdown-args-desc
   (conj datepicker-args-desc
-        {:name :format    :required false  :default "yyyy MMM dd"  :type "string"   :description "[datepicker-dropdown only] a represenatation of a date format. See cljs_time.format"}
-        {:name :no-clip?  :required false  :default true           :type "boolean"  :description "[datepicker-dropdown only] when an anchor is in a scrolling region (e.g. scroller component), the popover can sometimes be clipped. When this parameter is true (which is the default), re-com will use a different CSS method to show the popover. This method is slightly inferior because the popover can't track the anchor if it is repositioned"}))
+        {:name :format       :required false  :default "yyyy MMM dd"  :type "string"   :description "[datepicker-dropdown only] a represenatation of a date format. See cljs_time.format"}
+        {:name :no-clip?     :required false  :default true           :type "boolean"  :description "[datepicker-dropdown only] when an anchor is in a scrolling region (e.g. scroller component), the popover can sometimes be clipped. When this parameter is true (which is the default), re-com will use a different CSS method to show the popover. This method is slightly inferior because the popover can't track the anchor if it is repositioned"}
+        {:name :placeholder  :required false                          :type "string"   :description "[datepicker-dropdown only] placeholder text for when a date is not selected."}))
 
 (defn datepicker-dropdown
   [& {:as args}]
@@ -268,22 +269,22 @@
         cancel-popover #(reset! shown? false)
         position       :below-left]
     (fn
-      [& {:keys [model show-weeks? on-change format no-clip?]
+      [& {:keys [model show-weeks? on-change format no-clip? placeholder]
           :or {no-clip? true}
           :as passthrough-args}]
       (let [collapse-on-select (fn [new-model]
                                  (reset! shown? false)
-                                 (when on-change (on-change new-model)))    ;; wrap callback to collapse popover
-            passthrough-args   (dissoc passthrough-args :format :no-clip?)  ;; :format and :no-clip? only valid at this API level
+                                 (when on-change (on-change new-model)))                 ;; wrap callback to collapse popover
+            passthrough-args   (dissoc passthrough-args :format :no-clip? :placeholder)  ;; :format, :no-clip? and :placeholder only valid at this API level
             passthrough-args   (->> (assoc passthrough-args :on-change collapse-on-select)
-                                    (merge {:hide-border? true})            ;; apply defaults
+                                    (merge {:hide-border? true})                         ;; apply defaults
                                     vec
                                     flatten)]
         [popover-anchor-wrapper
          :class    "rc-datepicker-dropdown-wrapper"
          :showing? shown?
          :position position
-         :anchor   [anchor-button shown? model format]
+         :anchor   [anchor-button shown? model format placeholder]
          :popover  [popover-content-wrapper
                     :position-offset (if show-weeks? 43 44)
                     :no-clip?       no-clip?


### PR DESCRIPTION
The datepicker dropdown can look a little bare when it's not initialized with a model. 
![image](https://user-images.githubusercontent.com/8739864/33443621-122005d4-d5c6-11e7-96d8-a37fcf4c48f0.png)

This PR adds an optional `:placeholder` option (for just the dropdown version) that's displayed when no date is selected. 
![image](https://user-images.githubusercontent.com/8739864/33443862-a8de6d1c-d5c6-11e7-9642-5083eeb7024b.png)
