### PR TITLE
Parametrize color of the svg arrow (stroke attribute)

### DIFF
--- a/src/re_com/popover.cljs
+++ b/src/re_com/popover.cljs
@@ -101,7 +101,7 @@
 
 (defn- popover-arrow
   "Render the triangle which connects the popover to the anchor (using SVG)"
-  [orientation pop-offset arrow-length arrow-width grey-arrow? no-border? popover-color]
+  [orientation pop-offset arrow-length arrow-width grey-arrow? no-border? popover-color popover-border-color]
   (let [half-arrow-width (/ arrow-width 2)
         arrow-shape {:left  (str (point 0 0)            (point arrow-length half-arrow-width) (point 0 arrow-width))
                      :right (str (point arrow-length 0) (point 0 half-arrow-width)            (point arrow-length arrow-width))
@@ -134,7 +134,7 @@
                  :style {:fill (if popover-color
                                  popover-color
                                  (if grey-arrow? "#f7f7f7" "white"))
-                         :stroke (when-not no-border? "rgba(0, 0, 0, .2)")
+                         :stroke (or popover-border-color (when-not no-border? "rgba(0, 0, 0, .2)"))
                          :stroke-width "1"}}]]))
 
 
@@ -236,7 +236,8 @@
    {:name :margin-left     :required false                       :type "string"           :validate-fn string?           :description "a CSS style describing the horiztonal offset from anchor after position"}
    {:name :margin-top      :required false                       :type "string"           :validate-fn string?           :description "a CSS style describing the vertical offset from anchor after position"}
    {:name :tooltip-style?  :required false :default false        :type "boolean"                                         :description "setup popover styles for a tooltip"}
-   {:name :title           :required false                       :type "string | markup"                                 :description "describes a title"}])
+   {:name :title           :required false                       :type "string | markup"                                 :description "describes a title"}
+   {:name :popover-border-color :required false                  :type "string"           :validate-fn string?           :description "color of the popover arrow stroke"}])
 
 (defn popover-border
   "Renders an element or control along with a Bootstrap popover"
@@ -277,7 +278,7 @@
 
        :reagent-render
        (fn
-         [& {:keys [children position position-offset width height popover-color arrow-length arrow-width arrow-gap padding margin-left margin-top tooltip-style? title]
+         [& {:keys [children position position-offset width height popover-color popover-border-color arrow-length arrow-width arrow-gap padding margin-left margin-top tooltip-style? title]
              :or {arrow-length 11 arrow-width 22 arrow-gap -1}
              :as args}]
          {:pre [(validate-args-macro popover-border-args-desc args "popover-border")]}
@@ -313,7 +314,7 @@
                             :opacity   (if @ready-to-show? "1" "0")
                             :max-width "none"
                             :padding   "0px"})}
-            [popover-arrow orientation @pop-offset arrow-length arrow-width grey-arrow? tooltip-style? popover-color]
+            [popover-arrow orientation @pop-offset arrow-length arrow-width grey-arrow? tooltip-style? popover-color popover-border-color]
             (when title title)
             (into [:div.popover-content {:style {:padding padding}}] children)]))})))
 
@@ -336,6 +337,7 @@
    {:name :body              :required false                        :type "string | hiccup"  :validate-fn string-or-hiccup? :description "describes the popover body. Must be a single component"}
    {:name :tooltip-style?    :required false  :default false        :type "boolean"                                         :description "setup popover styles for a tooltip"}
    {:name :popover-color     :required false  :default "white"      :type "string"           :validate-fn string?           :description "fill color of the popover"}
+   {:name :popover-border-color :required false                     :type "string"           :validate-fn string?           :description "color of the popover arrow stroke"}
    {:name :arrow-length      :required false  :default 11           :type "integer | string" :validate-fn number-or-string? :description "the length in pixels of the arrow (from pointy part to middle of arrow base)"}
    {:name :arrow-width       :required false  :default 22           :type "integer | string" :validate-fn number-or-string? :description "the width in pixels of arrow base"}
    {:name :arrow-gap         :required false  :default -1           :type "integer"          :validate-fn number?           :description "px gap between the anchor and the arrow tip. Positive numbers push the popover away from the anchor"}
@@ -372,7 +374,7 @@
        :reagent-render
        (fn
          [& {:keys [showing-injected? position-injected position-offset no-clip? width height backdrop-opacity on-cancel title
-                    close-button? body tooltip-style? popover-color arrow-length arrow-width arrow-gap padding class style attr]
+                    close-button? body tooltip-style? popover-color popover-border-color arrow-length arrow-width arrow-gap padding class style attr]
              :or {arrow-length 11 arrow-width 22 arrow-gap -1}
              :as args}]
          {:pre [(validate-args-macro popover-content-wrapper-args-desc args "popover-content-wrapper")]}
@@ -397,6 +399,7 @@
            :height          height
            :tooltip-style?  tooltip-style?
            :popover-color   popover-color
+           :popover-border-color popover-border-color
            :arrow-length    arrow-length
            :arrow-width     arrow-width
            :arrow-gap       arrow-gap

--- a/src/re_com/popover.cljs
+++ b/src/re_com/popover.cljs
@@ -223,21 +223,21 @@
     (or (some? clip-left) (some? clip-right) (some? clip-top) (some? clip-bottom))))        ;; Return boolean
 
 (def popover-border-args-desc
-  [{:name :children        :required true                        :type "vector"           :validate-fn sequential?       :description "a vector of component markups"}
-   {:name :position        :required true                        :type "keyword atom"     :validate-fn position?         :description [:span "relative to this anchor. One of " position-options-list]}
-   {:name :position-offset :required false                       :type "integer"          :validate-fn number?           :description [:span "px offset of the arrow from its default " [:code ":position"] " along the popover border. Is ignored when " [:code ":position"] " is one of the " [:code ":xxx-center"] " variants. Positive numbers slide the popover toward its center"]}
-   {:name :width           :required false                       :type "string"           :validate-fn string?           :description "a CSS style describing the popover width"}
-   {:name :height          :required false :default "auto"       :type "string"           :validate-fn string?           :description "a CSS style describing the popover height"}
-   {:name :popover-color   :required false :default "white"      :type "string"           :validate-fn string?           :description "fill color of the popover"}
-   {:name :arrow-length    :required false :default 11           :type "integer | string" :validate-fn number-or-string? :description "the length in pixels of the arrow (from pointy part to middle of arrow base)"}
-   {:name :arrow-width     :required false :default 22           :type "integer | string" :validate-fn number-or-string? :description "the width in pixels of arrow base"}
-   {:name :arrow-gap       :required false :default -1           :type "integer"          :validate-fn number?           :description "px gap between the anchor and the arrow tip. Positive numbers push the popover away from the anchor"}
-   {:name :padding         :required false                       :type "string"           :validate-fn string?           :description "a CSS style which overrides the inner padding of the popover"}
-   {:name :margin-left     :required false                       :type "string"           :validate-fn string?           :description "a CSS style describing the horiztonal offset from anchor after position"}
-   {:name :margin-top      :required false                       :type "string"           :validate-fn string?           :description "a CSS style describing the vertical offset from anchor after position"}
-   {:name :tooltip-style?  :required false :default false        :type "boolean"                                         :description "setup popover styles for a tooltip"}
-   {:name :title           :required false                       :type "string | markup"                                 :description "describes a title"}
-   {:name :popover-border-color :required false                  :type "string"           :validate-fn string?           :description "color of the popover arrow stroke"}])
+  [{:name :children             :required true                        :type "vector"           :validate-fn sequential?       :description "a vector of component markups"}
+   {:name :position             :required true                        :type "keyword atom"     :validate-fn position?         :description [:span "relative to this anchor. One of " position-options-list]}
+   {:name :position-offset      :required false                       :type "integer"          :validate-fn number?           :description [:span "px offset of the arrow from its default " [:code ":position"] " along the popover border. Is ignored when " [:code ":position"] " is one of the " [:code ":xxx-center"] " variants. Positive numbers slide the popover toward its center"]}
+   {:name :width                :required false                       :type "string"           :validate-fn string?           :description "a CSS style describing the popover width"}
+   {:name :height               :required false :default "auto"       :type "string"           :validate-fn string?           :description "a CSS style describing the popover height"}
+   {:name :popover-color        :required false :default "white"      :type "string"           :validate-fn string?           :description "fill color of the popover"}
+   {:name :arrow-length         :required false :default 11           :type "integer | string" :validate-fn number-or-string? :description "the length in pixels of the arrow (from pointy part to middle of arrow base)"}
+   {:name :arrow-width          :required false :default 22           :type "integer | string" :validate-fn number-or-string? :description "the width in pixels of arrow base"}
+   {:name :arrow-gap            :required false :default -1           :type "integer"          :validate-fn number?           :description "px gap between the anchor and the arrow tip. Positive numbers push the popover away from the anchor"}
+   {:name :padding              :required false                       :type "string"           :validate-fn string?           :description "a CSS style which overrides the inner padding of the popover"}
+   {:name :margin-left          :required false                       :type "string"           :validate-fn string?           :description "a CSS style describing the horiztonal offset from anchor after position"}
+   {:name :margin-top           :required false                       :type "string"           :validate-fn string?           :description "a CSS style describing the vertical offset from anchor after position"}
+   {:name :tooltip-style?       :required false :default false        :type "boolean"                                         :description "setup popover styles for a tooltip"}
+   {:name :title                :required false                       :type "string | markup"                                 :description "describes a title"}
+   {:name :popover-border-color :required false                       :type "string"           :validate-fn string?           :description "color of the popover arrow stroke"}])
 
 (defn popover-border
   "Renders an element or control along with a Bootstrap popover"
@@ -324,27 +324,27 @@
 ;;--------------------------------------------------------------------------------------------------
 
 (def popover-content-wrapper-args-desc
-  [{:name :showing-injected? :required true                         :type "boolean atom"                                    :description [:span "an atom. When the value is true, the popover shows." [:br] [:strong "NOTE: "] "When used as direct " [:code ":popover"] " arg in popover-anchor-wrapper, this arg will be injected automatically by popover-anchor-wrapper. If using your own popover function, you must add this yourself"]}
-   {:name :position-injected :required true                         :type "keyword atom"     :validate-fn position?         :description [:span "relative to this anchor. One of " position-options-list [:br] [:strong "NOTE: "] "See above NOTE for " [:code ":showing-injected?"] ". Same applies" ]}
-   {:name :position-offset   :required false                        :type "integer"          :validate-fn number?           :description [:span "px offset of the arrow from its default " [:code ":position"] " along the popover border. Is ignored when " [:code ":position"] " is one of the " [:code ":xxx-center"] " variants. Positive numbers slide the popover toward its center"]}
-   {:name :no-clip?          :required false  :default false        :type "boolean"                                         :description "when an anchor is in a scrolling region (e.g. scroller component), the popover can sometimes be clipped. By passing true for this parameter, re-com will use a different CSS method to show the popover. This method is slightly inferior because the popover can't track the anchor if it is repositioned"}
-   {:name :width             :required false                        :type "string"           :validate-fn string?           :description "a CSS style representing the popover width"}
-   {:name :height            :required false                        :type "string"           :validate-fn string?           :description "a CSS style representing the popover height"}
-   {:name :backdrop-opacity  :required false  :default 0.0          :type "double | string"  :validate-fn number-or-string? :description "indicates the opacity of the backdrop where 0.0=transparent, 1.0=opaque"}
-   {:name :on-cancel         :required false                        :type "-> nil"           :validate-fn fn?               :description "a function which takes no params and returns nothing. Called when the popover is cancelled (e.g. user clicks away)"}
-   {:name :title             :required false                        :type "string | hiccup"  :validate-fn string-or-hiccup? :description "describes the title of the popover. The default font size is 18px to make it stand out"}
-   {:name :close-button?     :required false  :default true         :type "boolean"                                         :description "when true, displays the close button"}
-   {:name :body              :required false                        :type "string | hiccup"  :validate-fn string-or-hiccup? :description "describes the popover body. Must be a single component"}
-   {:name :tooltip-style?    :required false  :default false        :type "boolean"                                         :description "setup popover styles for a tooltip"}
-   {:name :popover-color     :required false  :default "white"      :type "string"           :validate-fn string?           :description "fill color of the popover"}
-   {:name :popover-border-color :required false                     :type "string"           :validate-fn string?           :description "color of the popover arrow stroke"}
-   {:name :arrow-length      :required false  :default 11           :type "integer | string" :validate-fn number-or-string? :description "the length in pixels of the arrow (from pointy part to middle of arrow base)"}
-   {:name :arrow-width       :required false  :default 22           :type "integer | string" :validate-fn number-or-string? :description "the width in pixels of arrow base"}
-   {:name :arrow-gap         :required false  :default -1           :type "integer"          :validate-fn number?           :description "px gap between the anchor and the arrow tip. Positive numbers push the popover away from the anchor"}
-   {:name :padding           :required false                        :type "string"           :validate-fn string?           :description "a CSS style which overrides the inner padding of the popover"}
-   {:name :class             :required false                        :type "string"           :validate-fn string?           :description "CSS class names, space separated (applies to the outer container)"}
-   {:name :style             :required false                        :type "CSS style map"    :validate-fn css-style?        :description "override component style(s) with a style map, only use in case of emergency (applies to the outer container)"}
-   {:name :attr              :required false                        :type "HTML attr map"    :validate-fn html-attr?        :description [:span "HTML attributes, like " [:code ":on-mouse-move"] [:br] "No " [:code ":class"] " or " [:code ":style"] "allowed (applies to the outer container)"]}])
+  [{:name :showing-injected?    :required true                         :type "boolean atom"                                    :description [:span "an atom. When the value is true, the popover shows." [:br] [:strong "NOTE: "] "When used as direct " [:code ":popover"] " arg in popover-anchor-wrapper, this arg will be injected automatically by popover-anchor-wrapper. If using your own popover function, you must add this yourself"]}
+   {:name :position-injected    :required true                         :type "keyword atom"     :validate-fn position?         :description [:span "relative to this anchor. One of " position-options-list [:br] [:strong "NOTE: "] "See above NOTE for " [:code ":showing-injected?"] ". Same applies" ]}
+   {:name :position-offset      :required false                        :type "integer"          :validate-fn number?           :description [:span "px offset of the arrow from its default " [:code ":position"] " along the popover border. Is ignored when " [:code ":position"] " is one of the " [:code ":xxx-center"] " variants. Positive numbers slide the popover toward its center"]}
+   {:name :no-clip?             :required false  :default false        :type "boolean"                                         :description "when an anchor is in a scrolling region (e.g. scroller component), the popover can sometimes be clipped. By passing true for this parameter, re-com will use a different CSS method to show the popover. This method is slightly inferior because the popover can't track the anchor if it is repositioned"}
+   {:name :width                :required false                        :type "string"           :validate-fn string?           :description "a CSS style representing the popover width"}
+   {:name :height               :required false                        :type "string"           :validate-fn string?           :description "a CSS style representing the popover height"}
+   {:name :backdrop-opacity     :required false  :default 0.0          :type "double | string"  :validate-fn number-or-string? :description "indicates the opacity of the backdrop where 0.0=transparent, 1.0=opaque"}
+   {:name :on-cancel            :required false                        :type "-> nil"           :validate-fn fn?               :description "a function which takes no params and returns nothing. Called when the popover is cancelled (e.g. user clicks away)"}
+   {:name :title                :required false                        :type "string | hiccup"  :validate-fn string-or-hiccup? :description "describes the title of the popover. The default font size is 18px to make it stand out"}
+   {:name :close-button?        :required false  :default true         :type "boolean"                                         :description "when true, displays the close button"}
+   {:name :body                 :required false                        :type "string | hiccup"  :validate-fn string-or-hiccup? :description "describes the popover body. Must be a single component"}
+   {:name :tooltip-style?       :required false  :default false        :type "boolean"                                         :description "setup popover styles for a tooltip"}
+   {:name :popover-color        :required false  :default "white"      :type "string"           :validate-fn string?           :description "fill color of the popover"}
+   {:name :popover-border-color :required false                        :type "string"           :validate-fn string?           :description "color of the popover arrow stroke"}
+   {:name :arrow-length         :required false  :default 11           :type "integer | string" :validate-fn number-or-string? :description "the length in pixels of the arrow (from pointy part to middle of arrow base)"}
+   {:name :arrow-width          :required false  :default 22           :type "integer | string" :validate-fn number-or-string? :description "the width in pixels of arrow base"}
+   {:name :arrow-gap            :required false  :default -1           :type "integer"          :validate-fn number?           :description "px gap between the anchor and the arrow tip. Positive numbers push the popover away from the anchor"}
+   {:name :padding              :required false                        :type "string"           :validate-fn string?           :description "a CSS style which overrides the inner padding of the popover"}
+   {:name :class                :required false                        :type "string"           :validate-fn string?           :description "CSS class names, space separated (applies to the outer container)"}
+   {:name :style                :required false                        :type "CSS style map"    :validate-fn css-style?        :description "override component style(s) with a style map, only use in case of emergency (applies to the outer container)"}
+   {:name :attr                 :required false                        :type "HTML attr map"    :validate-fn html-attr?        :description [:span "HTML attributes, like " [:code ":on-mouse-move"] [:br] "No " [:code ":class"] " or " [:code ":style"] "allowed (applies to the outer container)"]}])
 
 (defn popover-content-wrapper
   "Abstracts several components to handle the 90% of cases for general popovers and dialog boxes"
@@ -393,23 +393,23 @@
              :opacity  backdrop-opacity
              :on-click on-cancel])
           [popover-border
-           :position        position-injected
-           :position-offset position-offset
-           :width           width
-           :height          height
-           :tooltip-style?  tooltip-style?
-           :popover-color   popover-color
+           :position             position-injected
+           :position-offset      position-offset
+           :width                width
+           :height               height
+           :tooltip-style?       tooltip-style?
+           :popover-color        popover-color
            :popover-border-color popover-border-color
-           :arrow-length    arrow-length
-           :arrow-width     arrow-width
-           :arrow-gap       arrow-gap
-           :padding         padding
-           :title           (when title [popover-title
-                                         :title          title
-                                         :showing?       showing-injected?
-                                         :close-button?  close-button?
-                                         :close-callback on-cancel])
-           :children        [body]]])})))
+           :arrow-length         arrow-length
+           :arrow-width          arrow-width
+           :arrow-gap            arrow-gap
+           :padding              padding
+           :title                (when title [popover-title
+                                             :title          title
+                                             :showing?       showing-injected?
+                                             :close-button?  close-button?
+                                             :close-callback on-cancel])
+           :children             [body]]])})))
 
 
 ;;--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Currently we can apply css style to the popover box, but cannot change the color of svg arrow.
This PR fixes it