### PR TITLE
datepicker: loosen model validation in datepicker to DateTimeProtocol

### DIFF
--- a/src/re_com/validate.cljs
+++ b/src/re_com/validate.cljs
@@ -1,12 +1,11 @@
 (ns re-com.validate
   (:require
+    [cljs-time.core :as time.core]
     [clojure.set           :refer [superset?]]
     [re-com.util           :refer [deref-or-value-peek]]
     [reagent.core          :as    reagent]
     [reagent.impl.template :refer [valid-tag?]]
-    [goog.string           :as    gstring]
-    [goog.date.UtcDateTime]
-    [goog.date.Date]))
+    [goog.string           :as    gstring]))
 
 
 ;; -- Helpers -----------------------------------------------------------------
@@ -344,11 +343,11 @@
                  {:status  (if (or contains-class? contains-style?) :error :warning)
                   :message result}))))))
 
-(defn goog-date?
-  "Returns true if the passed argument is a valid goog.date.UtcDateTime or goog.date.Date, otherwise false/error"
+(defn date-like?
+  "Returns true if arg satisfies cljs-time.core/DateTimeProtocol typically goog.date.UtcDateTime or goog.date.Date,
+   otherwise false/error."
   [arg]
-  (let [arg (deref-or-value-peek arg)]
-    (or (= js/goog.date.UtcDateTime (type arg)) (= js/goog.date.Date (type arg)))))
+  (-> arg deref-or-value-peek time.core/date?))
 
 (defn regex?
   "Returns true if the passed argument is a valid regular expression, otherwise false/error"

--- a/src/re_com/validate.cljs
+++ b/src/re_com/validate.cljs
@@ -1,6 +1,6 @@
 (ns re-com.validate
   (:require
-    [cljs-time.core :as time.core]
+    [cljs-time.core        :as    time.core]
     [clojure.set           :refer [superset?]]
     [re-com.util           :refer [deref-or-value-peek]]
     [reagent.core          :as    reagent]

--- a/src/re_demo/datepicker.cljs
+++ b/src/re_demo/datepicker.cljs
@@ -113,7 +113,7 @@
                                            :show-today?   @show-today?
                                            :show-weeks?   @show-weeks?
                                            :selectable-fn selectable-pred
-                                           :on-change     #(reset! model1 %)]
+                                           :on-change     #(do #_(js/console.log "model1:" %) (reset! model1 %))]
                                           [label :style label-style :label (str "selected: " (date->string @model1))]
                                           [h-box
                                            :gap      "6px"
@@ -154,7 +154,7 @@
                                            :show-weeks?   @show-weeks?
                                            :selectable-fn selectable-pred
                                            :disabled?     disabled?
-                                           :on-change     #(reset! model2 %)]
+                                           :on-change     #(do #_(js/console.log "model2" %) (reset! model2 %))]
                                           [label :style label-style :label (str "selected: " (date->string @model2))]]]]]
                   enabled-days
                   disabled?

--- a/src/re_demo/datepicker.cljs
+++ b/src/re_demo/datepicker.cljs
@@ -8,7 +8,7 @@
     [cljs-time.format  :refer [formatter unparse]]
     [re-com.core       :refer [h-box v-box box gap single-dropdown datepicker datepicker-dropdown checkbox label title p button md-icon-button]]
     [re-com.datepicker :refer [iso8601->date datepicker-dropdown-args-desc]]
-    [re-com.validate   :refer [goog-date?]]
+    [re-com.validate   :refer [date-like?]]
     [re-com.util       :refer [now->utc]]
     [re-demo.utils     :refer [panel-title title2 args-table github-hyperlink status-text]]))
 
@@ -77,7 +77,7 @@
 
 (defn- date->string
   [date]
-  (if (goog-date? date)
+  (if (date-like? date)
     (unparse (formatter "dd MMM, yyyy") date)
     "no date"))
 
@@ -123,17 +123,17 @@
                                                       [md-icon-button
                                                        :md-icon-name "zmdi-arrow-left"
                                                        :size         :smaller
-                                                       :disabled?    (not (goog-date? @model1))
-                                                       :on-click     #(when (goog-date? @model1)
+                                                       :disabled?    (not (date-like? @model1))
+                                                       :on-click     #(when (date-like? @model1)
                                                                         (reset! model1 (minus @model1 (days 1))))]
                                                       [md-icon-button
                                                        :md-icon-name "zmdi-arrow-right"
                                                        :size         :smaller
-                                                       :disabled?    (if (and (goog-date? @model1) (goog-date? @model2))
+                                                       :disabled?    (if (and (date-like? @model1) (date-like? @model2))
                                                                        (not (before? (to-local-date @model1)
                                                                                      (to-local-date @model2)))
                                                                        true)
-                                                       :on-click     #(when (goog-date? @model1)
+                                                       :on-click     #(when (date-like? @model1)
                                                                         (reset! model1 (plus @model1 (days 1))))]
                                                       [button
                                                        :label    "Reset"


### PR DESCRIPTION
Rename re-com.validate/goog-date? to date-like? and test arg via
cljs-time.core/date? which ensures it satisfies DateTimeProtocol instead
of concrete type checks. This allows consumers to provide their own
date like objects `e.g. day8.time.Date` which may not subclass goog.date.Date for :model,
 :minimum & :maximum args.