### PR TITLE
Retain Focus On Enter In Typeahead

### DIFF
--- a/src/re_com/typeahead.cljs
+++ b/src/re_com/typeahead.cljs
@@ -205,7 +205,7 @@
   (condp = (.-which event)
     goog.events.KeyCodes.UP     (swap! state-atom activate-suggestion-prev)
     goog.events.KeyCodes.DOWN   (swap! state-atom activate-suggestion-next)
-    goog.events.KeyCodes.ENTER  (swap! state-atom choose-suggestion-active)
+    goog.events.KeyCodes.ENTER  (do (swap! state-atom choose-suggestion-active) (.focus (aget event "target")))
     goog.events.KeyCodes.ESC    (swap! state-atom got-suggestions [])
     ;; tab requires special treatment
     ;; trap it IFF there are suggestions, otherwise let the input defocus


### PR DESCRIPTION
After selecting an option from the list of values after typing in a desired string value, the focus is lost and users probably have to use the mouse to point to the typeahead input field again or use the combination of TAB and SHIFT+TAB to regain focus. This is a small feature I wanted to propose to save some time.