### PR TITLE
Fix tabbing over typeahead elements

### DIFF
--- a/src/re_com/typeahead.cljs
+++ b/src/re_com/typeahead.cljs
@@ -148,7 +148,7 @@
     (update-model state input-text)
     :else (-> state
               ;; if nothing was actually selected, then view should be the unchanged value
-              (assoc :input-text model)
+              (assoc :input-text input-text)
               clear-suggestions)))
 
 (defn- change-data-source


### PR DESCRIPTION
Related to: https://github.com/Day8/re-com/issues/190

Whenever a user tries to tab out of a typeahead box, if the 2
conditions in the `and` of `re-com.typeahead/input-text-will-blur`
aren't met, then the local state-atom for typeahead is replaced with
`nil` instead of having its value updated. This causes the entire
component to just break.