### PR TITLE
Add 15 new attributes and 1 fix to single-dropdown

### DIFF
--- a/run/resources/public/assets/css/re-com.css
+++ b/run/resources/public/assets/css/re-com.css
@@ -501,6 +501,74 @@ html, body {
   background-image: none;
 }
 
+/* Free-text drop-down */
+.chosen-container .free-text input {
+  display: inline-block;
+  padding-left: 12px !important;
+  padding-right: 27px !important;
+}
+
+.chosen-container .free-text .b-wrapper {
+  display: inline-block;
+  position: absolute;
+  right: 0;
+  padding-left: 7px;
+  padding-right: 2px;
+  cursor: pointer;
+}
+
+.chosen-container .free-text b {
+  display: inline-block;
+  background: url("chosen-sprite.png") no-repeat 0 7px;
+  width: 16px;
+  height: 28px;
+}
+
+.chosen-container.chosen-with-drop .free-text b {
+  background-position: -18px 7px !important;
+}
+
+/* The two rules below copied from .chosen-container-single .chosen-search above (support for filter box in free-text drop-down) */
+.chosen-container-multi .chosen-search {
+  margin: 0;
+  padding: 3px 4px;
+  position: relative;
+  white-space: nowrap;
+  z-index: 1000;
+}
+.chosen-container-multi .chosen-search input[type="text"] {
+  background: url("chosen-sprite.png") no-repeat 100% -20px, #ffffff;
+  border: 1px solid #cccccc;
+  border-top-right-radius: 4px;
+  border-top-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+  margin: 1px 0;
+  padding: 4px 20px 4px 4px;
+  width: 100%;
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-resolution: 144dpi) {
+  .chosen-container .free-text b,
+  .chosen-container-multi .chosen-search input[type="text"] {
+    background-image: url("chosen-sprite@2x.png") !important;
+    background-size: 52px 37px !important;
+    background-repeat: no-repeat !important;
+  }
+}
+
+/* Drop-down filter placeholder color */
+.chosen-container .chosen-search input::-webkit-input-placeholder {
+  color: #bbb;
+}
+
+/* Fix for width 100% dropdown in a flex container */
+.chosen-container-multi .chosen-choices .search-field {
+  width: 100%;
+}
+
 /*----------------------------------------------------------------------------------------
  Stylesheet for re-com.date Date Picker variants inline-picker & dropdown-picker
  Day8 variation loosely based on:

--- a/src/re_demo/dropdowns.cljs
+++ b/src/re_demo/dropdowns.cljs
@@ -1,20 +1,22 @@
 (ns re-demo.dropdowns
-  (:require [re-com.core     :refer [h-box v-box box gap single-dropdown input-text checkbox label title hyperlink-href p p-span]]
+  (:require [re-com.core     :refer [h-box v-box box gap single-dropdown input-text checkbox label title hyperlink-href p p-span line]]
             [re-com.dropdown :refer [filter-choices-by-keyword single-dropdown-args-desc]]
             [re-com.util     :refer [item-for-id]]
             [re-demo.utils   :refer [panel-title title2 args-table github-hyperlink status-text]]
             [reagent.core    :as    reagent]))
 
 
-(def demos [{:id 1 :label "Simple dropdown"}
-            {:id 2 :label "Dropdown with grouping"}
-            {:id 3 :label "Dropdown with filtering"}
+(def demos [{:id 1  :label "Simple dropdown"}
+            {:id 2  :label "Dropdown with grouping"}
+            {:id 3  :label "Dropdown with filtering"}
             ;{:id 4 :label "Use of :id-fn etc."} ;; for testing
-            {:id 5 :label "Keyboard support"}
-            {:id 6 :label "Other parameters"}
-            {:id 7 :label "Two dependent dropdowns"}
-            {:id 8 :label "Custom markup"}
-            {:id 9 :label "Async choices load"}])
+            {:id 5  :label "Keyboard support"}
+            {:id 6  :label "Other parameters"}
+            {:id 7  :label "Two dependent dropdowns"}
+            {:id 8  :label "Custom markup"}
+            {:id 9  :label "Async choices load"}
+            {:id 10 :label "Drop above"}
+            {:id 11 :label "Free text"}])
 
 
 (def countries [{:id "au" :label "Australia"}
@@ -240,9 +242,20 @@
 (defn other-params-demo
   []
   (let [selected-country-id (reagent/atom "US")
+        change-count        (reagent/atom 0)
+        drop-count          (reagent/atom 0)
         disabled?           (reagent/atom false)
         regex?              (reagent/atom false)
         width?              (reagent/atom false)
+        tooltip?            (reagent/atom false)
+        tooltip-position?   (reagent/atom false)
+        enter-drop?         (reagent/atom true)
+        cancelable?         (reagent/atom true)
+        filter-placeholder? (reagent/atom false)
+        just-drop?          (reagent/atom false)
+        repeat-change?      (reagent/atom false)
+        i18n?               (reagent/atom false)
+        on-drop?            (reagent/atom false)
         dropdown-width      "300px"]
     (fn []
       [v-box
@@ -253,17 +266,17 @@
                    :children [[checkbox
                                :label [box :align :start :child [:code ":disabled?"]]
                                :model disabled?
-                               :label-style {:width "130px"}
+                               :label-style {:width "165px"}
                                :on-change #(reset! disabled? %)]
                               [:span (str @disabled? " - " (if @disabled?
-                                                             "the dropwdown is locked and cannot be changed."
+                                                             "the dropdown is locked and cannot be changed."
                                                              "the dropdown is enabled and a choice can be selected."))]]]
                   [h-box
                    :align    :center
                    :children [[checkbox
                                :label [box :align :start :child [:code ":regex-filter?"]]
                                :model regex?
-                               :label-style {:width "130px"}
+                               :label-style {:width "165px"}
                                :on-change #(reset! regex? %)]
                               [:span (str @regex? " - " (if @regex?
                                                           "the filter text box supports JavaScript regular expressions."
@@ -273,23 +286,128 @@
                    :children [[checkbox
                                :label [box :align :start :child [:code ":width"]]
                                :model width?
-                               :label-style {:width "130px"}
+                               :label-style {:width "165px"}
                                :on-change #(reset! width? %)]
                               [:span (str (if @width?
                                             (str "\"" dropdown-width "\" - the dropdown is fixed to this width.")
                                             "not specified - the dropdown takes up all available width."))]]]
+                  [h-box
+                   :align    :center
+                   :children [[checkbox
+                               :label [box :align :start :child [:code ":tooltip"]]
+                               :model tooltip?
+                               :label-style {:width "165px"}
+                               :on-change #(reset! tooltip? %)]
+                              [:span (if @tooltip?
+                                       "hover over the dropdown to see the tooltip."
+                                       "no tooltip specified.")]]]
+                  [h-box
+                   :align    :center
+                   :children [[checkbox
+                               :label [box :align :start :child [:code ":tooltip-position"]]
+                               :model tooltip-position?
+                               :label-style {:width "165px"}
+                               :disabled? (not @tooltip?)
+                               :on-change #(reset! tooltip-position? %)]
+                              [:span (cond
+                                       (not @tooltip?)    "does not apply."
+                                       @tooltip-position? "the tooltip will appear on the right hand side of the dropdown."
+                                       :else              "not specified - the tooltip will appear below the dropdown.")]]]
+                  [h-box
+                   :align    :center
+                   :children [[checkbox
+                               :label [box :align :start :child [:code ":enter-drop?"]]
+                               :model enter-drop?
+                               :label-style {:width "165px"}
+                               :on-change #(reset! enter-drop? %)]
+                              [:span (str @enter-drop? " - " (if @enter-drop?
+                                                               "pressing Enter (while focused) displays the dropdown part."
+                                                               "pressing Enter (while focused) does not display the dropdown part."))]]]
+                  [h-box
+                   :align    :start
+                   :children [[checkbox
+                               :label [box :align :start :child [:code ":cancelable?"]]
+                               :model cancelable?
+                               :label-style {:width "165px"}
+                               :on-change #(reset! cancelable? %)]
+                              [:span (str @cancelable? " - " (if @cancelable?
+                                                               "selection made with arrow keys can be cancelled by pressing Esc or clicking outside the dropdown part."
+                                                               "selection made with arrow keys is immediately applied and thus cannot be cancelled."))]]]
+                  [h-box
+                   :align    :center
+                   :children [[checkbox
+                               :label [box :align :start :child [:code ":filter-placeholder"]]
+                               :model filter-placeholder?
+                               :label-style {:width "165px"}
+                               :on-change #(reset! filter-placeholder? %)]
+                              [:span (str (if @filter-placeholder?
+                                            "a placeholder text will be displayed when the filter is empty."
+                                            "not specified - no placeholder text will be displayed in the filter textbox."))]]]
+                  [h-box
+                   :align    :center
+                   :children [[checkbox
+                               :label [box :align :start :child [:code ":just-drop?"]]
+                               :model just-drop?
+                               :label-style {:width "165px"}
+                               :on-change #(reset! just-drop? %)]
+                              [:span (str @just-drop? " - " (if @just-drop?
+                                                              "just the dropdown part display."
+                                                              "normal display."))]]]
+                  [h-box
+                   :align    :center
+                   :children [[checkbox
+                               :label [box :align :start :child [:code ":repeat-change?"]]
+                               :model repeat-change?
+                               :label-style {:width "165px"}
+                               :on-change #(reset! repeat-change? %)]
+                              [:span (str @repeat-change? " - " (if @repeat-change?
+                                                                  (str "the change count of " @change-count " will increase if an item is re-selected.")
+                                                                  (str "the change count of " @change-count " will not increase if an item is re-selected.")))]]]
+                  [h-box
+                   :align    :center
+                   :children [[checkbox
+                               :label [box :align :start :child [:code ":i18n"]]
+                               :model i18n?
+                               :label-style {:width "165px"}
+                               :on-change #(reset! i18n? %)]
+                              [:span (if @i18n?
+                                       "type e.g. \"1\" in the filter box to see the \"No results match\" message translated."
+                                       "no internationalization applied.")]]]
+                  [h-box
+                   :align    :center
+                   :children [[checkbox
+                               :label [box :align :start :child [:code ":on-drop?"]]
+                               :model on-drop?
+                               :label-style {:width "165px"}
+                               :on-change #(reset! on-drop? %)]
+                              [:span (str @on-drop? " - " (if @on-drop?
+                                                            (str "the drop count of " @drop-count " will increase on the dropdown part display.")
+                                                            (str "the drop count of " @drop-count " will not increase on the dropdown part display.")))]]]
                   [gap :size "10px"]
                   [h-box
                    :gap      "10px"
                    :align    :center
-                   :children [[single-dropdown
-                               :choices       grouped-countries
-                               :model         selected-country-id
-                               :disabled?     @disabled?
-                               :filter-box?   true
-                               :regex-filter? @regex?
-                               :width         (when @width? dropdown-width)
-                               :on-change     #(reset! selected-country-id %)]
+                   :children [^{:key (str @just-drop? @on-drop?)}
+                              [single-dropdown
+                               :choices            grouped-countries
+                               :model              selected-country-id
+                               :disabled?          @disabled?
+                               :filter-box?        true
+                               :regex-filter?      @regex?
+                               :width              (when @width? dropdown-width)
+                               :tooltip            (when @tooltip? "An example tooltip")
+                               :tooltip-position   (when @tooltip-position? :right-center)
+                               :enter-drop?        @enter-drop?
+                               :cancelable?        @cancelable?
+                               :filter-placeholder (when @filter-placeholder? "An example filter placeholder")
+                               :just-drop?         @just-drop?
+                               :repeat-change?     @repeat-change?
+                               :i18n               (when @i18n? {:no-results-match "Brak wyników odpowiadających \"%s\""})
+                               :on-change          #(do
+                                                     (swap! change-count inc)
+                                                     (reset! selected-country-id %))
+                               :on-drop            (when @on-drop?
+                                                     #(swap! drop-count inc))]
                               [:div
                                [:strong "Selected country: "]
                                (if (nil? @selected-country-id)
@@ -422,61 +540,148 @@
                    :max-height "400px"
                    :on-change #(reset! selected-country-id2 %)]]])))
 
-(defn panel2
+(defn drop-above-demo
   []
-  (let [selected-demo-id (reagent/atom 1)]
+  (let [selected-city-id (reagent/atom nil)]
     (fn []
       [v-box
-       :size     "auto"
-       :gap      "10px"
-       :children [[panel-title "[single-dropdown ... ]"
-                                "src/re_com/dropdown.cljs"
-                                "src/re_demo/dropdowns.cljs"]
+       :gap      "100px"
+       :children [[p "When the " [:code ":can-drop-above?"] " attribute is set the dropdown part will be displayed above the top part if the space below it is too small."]
+                  [p "If items have non-standard height, the " [:code ":est-item-height"] "can be set to help guess where to display the dropdown part. This guess will be verified on the actual render so it is non-essential but can help eliminate an unnecessary redraw."]
                   [h-box
-                   :gap      "100px"
-                   :children [[v-box
-                               :gap      "10px"
-                               :width    "450px"
-                               :children [[title2 "Notes"]
-                                          [status-text "Stable"]
-                                           [p-span
-                                            "A dropdown selection component, similar to "
-                                            [hyperlink-href
-                                             :label  "Chosen"
-                                             :href   "http://harvesthq.github.io/chosen"
-                                             :target "_blank"]
-                                            ", styled using "
-                                            [hyperlink-href
-                                             :label  "Bootstrap"
-                                             :href   "https://github.com/alxlit/bootstrap-chosen"
-                                             :target "_blank"]
-                                            "."]
-                                           [p "Note: Single selection only."]
-                                          [args-table single-dropdown-args-desc]]]
-                              [v-box
-                               :width     "700px"
-                               :gap       "10px"
-                               :children  [[title2 "Demo"]
-                                           [h-box
-                                            :gap      "10px"
-                                            :align    :center
-                                            :children [[label :label "Select a demo"]
-                                                       [single-dropdown
-                                                        :choices   demos
-                                                        :model     selected-demo-id
-                                                        :width     "300px"
-                                                        :on-change #(reset! selected-demo-id %)]]]
-                                           [gap :size "0px"] ;; Force a bit more space here
-                                           (case @selected-demo-id
-                                             1 [simple-demo]
-                                             2 [grouping-demo]
-                                             3 [filtering-demo]
-                                             4 [id-fn-demo] ;; for testing - uncomment equivalent line in demos vector above
-                                             5 [keyboard-demo]
-                                             6 [other-params-demo]
-                                             7 [two-dependent-demo]
-                                             8 [custom-markup-demo]
-                                             9 [async-load-demo])]]]]]])))
+                   :gap      "10px"
+                   :align    :center
+                   :children [[single-dropdown
+                               :can-drop-above? true
+                               :choices         cities
+                               :model           selected-city-id
+                               :placeholder     "Choose a city"
+                               :width           "300px"
+                               :max-height      "500px"
+                               :on-change       #(reset! selected-city-id %)]
+                              [:div
+                               [:strong "Selected city: "]
+                               (if (nil? @selected-city-id)
+                                 "None"
+                                 (str (:label (item-for-id @selected-city-id cities)) " [" @selected-city-id "]"))]]]]])))
+
+(defn free-text-demo
+  []
+  (let [selected-city  (reagent/atom nil)
+        selected-city2 (reagent/atom nil)
+        auto-complete? (reagent/atom false)
+        capitalize?    (reagent/atom false)
+        f              (fn [a]
+                         [single-dropdown
+                          :free-text?      true
+                          :auto-complete?  @auto-complete?
+                          :capitalize?     @capitalize?
+                          :choices         (->> cities (mapv :label) sort)
+                          :model           a
+                          :placeholder     (str "Choose/type a city" (when @auto-complete? " or enter a first few letters"))
+                          :width           "350px"
+                          :on-change       #(reset! a %)])]
+    (fn []
+      [v-box
+       :gap "10px"
+       :children [[p "Allow user a free text input by setting the " [:code ":free-text?"] " attribute."]
+                  [p "Additional options:"]
+                  [checkbox
+                   :label [box :align :start :child [:code ":auto-complete?"]]
+                   :model auto-complete?
+                   :label-style {:width "165px"}
+                   :on-change #(reset! auto-complete? %)]
+                  [checkbox
+                   :label [box :align :start :child [:code ":capitalize?"]]
+                   :model capitalize?
+                   :label-style {:width "165px"}
+                   :on-change #(reset! capitalize? %)]
+                  [gap :size "10px"]
+                  [h-box
+                   :gap "10px"
+                   :align :center
+                   :children [(f selected-city)
+                              [:div
+                               [:strong "City: "]
+                               (if (seq @selected-city)
+                                 @selected-city
+                                 "None")]]]
+                  [gap :size "50px"]
+                  [line]
+                  [p "If the filter box is enabled, the filter text can be reused as the actual text entry. To try this, type e.g. \"1\" in the filter box and press Enter."]
+                  [:pre ":filter-box?   true\n:set-to-filter #{:on-enter-press :on-no-results-match-click}"]
+                  [gap :size "10px"]
+                  [h-box
+                   :gap "10px"
+                   :align :center
+                   :children [(conj (f selected-city2)
+                                :filter-box? true
+                                :set-to-filter #{:on-enter-press :on-no-results-match-click})
+                              [:div
+                               [:strong "City: "]
+                               (if (seq @selected-city2)
+                                 @selected-city2
+                                 "None")]]]]])))
+
+(defonce selected-demo-id (reagent/atom 1))
+
+(defn panel2
+  []
+  (fn []
+    [v-box
+     :size     "auto"
+     :gap      "10px"
+     :children [[panel-title "[single-dropdown ... ]"
+                              "src/re_com/dropdown.cljs"
+                              "src/re_demo/dropdowns.cljs"]
+                [h-box
+                 :gap      "100px"
+                 :children [[v-box
+                             :gap      "10px"
+                             :width    "450px"
+                             :children [[title2 "Notes"]
+                                        [status-text "Stable"]
+                                         [p-span
+                                          "A dropdown selection component, similar to "
+                                          [hyperlink-href
+                                           :label  "Chosen"
+                                           :href   "http://harvesthq.github.io/chosen"
+                                           :target "_blank"]
+                                          ", styled using "
+                                          [hyperlink-href
+                                           :label  "Bootstrap"
+                                           :href   "https://github.com/alxlit/bootstrap-chosen"
+                                           :target "_blank"]
+                                          "."]
+                                         [p "Note: Single selection only."]
+                                        [args-table single-dropdown-args-desc]]]
+                            [v-box
+                             :width     "700px"
+                             :gap       "10px"
+                             :children  [[title2 "Demo"]
+                                         [h-box
+                                          :gap      "10px"
+                                          :align    :center
+                                          :children [[label :label "Select a demo"]
+                                                     [single-dropdown
+                                                      :choices    demos
+                                                      :model      selected-demo-id
+                                                      :width      "300px"
+                                                      :max-height "300px"
+                                                      :on-change  #(reset! selected-demo-id %)]]]
+                                         [gap :size "0px"] ;; Force a bit more space here
+                                         (case @selected-demo-id
+                                           1  [simple-demo]
+                                           2  [grouping-demo]
+                                           3  [filtering-demo]
+                                           4  [id-fn-demo] ;; for testing - uncomment equivalent line in demos vector above
+                                           5  [keyboard-demo]
+                                           6  [other-params-demo]
+                                           7  [two-dependent-demo]
+                                           8  [custom-markup-demo]
+                                           9  [async-load-demo]
+                                           10 [drop-above-demo]
+                                           11 [free-text-demo])]]]]]]))
 
 
 ;; core holds a reference to panel, so need one level of indirection to get figwheel updates

--- a/test/re-com/dropdown_test.cljs
+++ b/test/re-com/dropdown_test.cljs
@@ -2,3 +2,42 @@
   (:require [cljs.test       :refer-macros [is are deftest]]
             [reagent.core    :as reagent]
             [re-com.dropdown :as dropdown]))
+
+(deftest auto-complete
+  (are [arg-map expected]
+    (let [{:keys [text sel ins]} arg-map]
+      (= (dropdown/auto-complete :choices   ["bar" "baz baz" "FOoo" "FOoooO"]
+                                 :text      text
+                                 :sel-start (first sel)
+                                 :sel-end   (second sel)
+                                 :ins       ins)
+         (some-> expected
+                 (dissoc :sel)
+                 (assoc :sel-start (first (:sel expected)))
+                 (assoc :sel-end (second (:sel expected))))))
+    {:text ""     :sel [0 0] :ins "a"}  nil
+    {:text ""     :sel [0 0] :ins "b"}  {:text "bar"     :sel [1 3]}
+    {:text "bar"  :sel [1 3] :ins "a"}  {:text "bar"     :sel [2 3]}
+    {:text "bar"  :sel [2 3] :ins "r"}  nil
+    {:text "bar"  :sel [3 3] :ins "r"}  nil
+    {:text "bar"  :sel [2 3] :ins "z"}  {:text "baz baz" :sel [3 7]}
+    {:text "bar"  :sel [2 3] :ins "x"}  nil
+    {:text ""     :sel [0 0] :ins "f"}  {:text "fOoo"    :sel [1 4]}
+    {:text "fOoo" :sel [1 4] :ins "o"}  {:text "fooo"    :sel [2 4]}
+    {:text "fooo" :sel [2 4] :ins "O"}  {:text "foOo"    :sel [3 4]}
+    {:text "foOo" :sel [3 4] :ins "O"}  nil
+    {:text "foOO" :sel [4 4] :ins "O"}  {:text "foOOOO"  :sel [5 6]}
+    {:text "foo"  :sel [0 3] :ins "F"}  {:text "FOoo"    :sel [1 4]}
+    {:text "bar"  :sel [1 2] :ins "a"}  {:text "bar"     :sel [2 3]}
+    {:text ""     :sel [0 0] :ins "Fo"} {:text "Fooo"    :sel [2 4]}
+    {:text nil    :sel [0 0] :ins "b"}  {:text "bar"     :sel [1 3]}
+    {:text ""     :sel [0 0] :ins nil}  nil
+    {:text ""     :sel [0 0] :ins ""}   nil))
+
+
+(deftest capitalize-first-letter
+  (are [argument expected] (= (dropdown/capitalize-first-letter argument)
+                              expected)
+        nil      nil
+        ""       ""
+        "foOo"   "FoOo"))


### PR DESCRIPTION
The new attributes:

* `:tooltip`             what to show in the tooltip
* `:tooltip-position`    relative to this anchor. One of :above-left, :above-center, :above-right, :below-left, :below-center, :below-right, :left-above, :left-center, :left-below, :right-above, :right-center, :right-below
* `:free-text?`          is the text freely editable? If true then :chocies is a vector of strings, :model is a string (atom) and :on-change is called with a string
* `:auto-complete?`      auto-complete text while typing using dropdown choices. Has no effect if :free-text? is not turned on
* `:capitalize?`         capitalize the first letter. Has no effect if :free-text? is not turned on
* `:enter-drop?`         should pressing Enter display the dropdown part? (true by default as this is the current behaviour)
* `:cancelable?`         should pressing Esc or clicking outside the dropdown part cancel selection made with arrow keys? (true by default as this is the current behaviour)
* `:set-to-filter`       when :filter-box? and :free-text? are turned on and there are no results, current text can be set to filter text :on-enter-press and/or :on-no-results-match-click
* `:filter-placeholder`  background text in filter box when no filter
* `:can-drop-above?`     should the dropdown part be displayed above if it does not fit below the top part?
* `:est-item-height`     estimated dropdown item height (for :can-drop-above?). used only *before* the dropdown part is displayed to guess whether it fits below the top part or not which is later verified when the dropdown is displayed
* `:just-drop?`          display just the dropdown part
* `:repeat-change?`      repeat :on-change events if an already selected item is selected again
* `:i18n`                internationalization map with optional keys :loading, :no-results and :no-results-match
* `:on-drop`             called when the dropdown part is displayed

These new attributes can be checked out on the [updated demo page](https://pawelstroinski.github.io/re-com/#/dropdown). The relevant demos: Other parameters, Drop above & Free text.

The fix:

* Keep focus after an item has been clicked.