### PR TITLE
Fix error when rewrite-clj reads uneval forms

### DIFF
--- a/scripts/add-at-macro/src/add_at_macro/core.clj
+++ b/scripts/add-at-macro/src/add_at_macro/core.clj
@@ -214,7 +214,7 @@
 
 (defn add-at-in-component
   "Given `loc` is a hiccup vector for a re-com component, such as `[box :child [...]]`, returns a modified vector
-  with the `:src` arguement added.
+  with the `:src` argument added.
 
   It transforms
     `[box :child [...]]`
@@ -237,8 +237,8 @@
 
 (defn find-recom-usages
   "Given `loc` is a rewrite-clj zipper, it searches for hiccup vectors involving re-com components. For each one
-  found, it calls `add-at-in-component` with that component to add `:src` to the arguements supplied.  As rewrite-clj
-  searches, it doesn't skip uneval forms (#_[<re-com-component> ...]) and so they will\n   also get :src annotations.
+  found, it calls `add-at-in-component` with that component to add `:src` to the arguments supplied.  As rewrite-clj
+  searches, it doesn't skip uneval forms such as (#_[<re-com-component> ...]) and so they will also get :src annotations.
 
    If zipper is for a form such as
      `(ns ...)


### PR DESCRIPTION
Currently reading a file with an uneval form results in an error, `operation not permitted`. 
As rewrite-clj loops through files, it skips whitespaces and comments but does not skip uneval forms such as `#_[re-com.core ...]`. This makes it extremely hard for us to know if the current component we are looping is an uneval form or code to execute.
For example if we have the component
```Clojure 
  [h-box
    :size "1"
    :children [#_[title :label "Hidden"]
               [v-box :children []]
               [box :child []]]]]]
```

If `rewrite-clj.zip/next` would skip uneval forms, we would've expected the next location, as we loop, to follow the path:
`[h-box ...]` -> `h-box` -> `:size` -> `"1"` -> `:children` -> `[#_[title ...]...]` -> `[v-box...]` -> `:children` -> `[]` -> etc

If `rewrite-clj` would have treated uneval forms as flat objects like strings we would've looped through:
`[h-box ...]` -> `h-box` -> `:size` -> `"1"` -> `:children` -> `[#_[title ...]...]` -> `#_[title...]` -> `[v-box...]` -> `:children` -> `[]` -> etc

but instead follows the path
`[h-box ...]` -> `h-box` -> `:size` -> `"1"` -> `:children` -> `[#_[title ...]...]` -> `#_[title...]` -> `[title ...]` -> `:label` -> `"Hidden"` -> `[v-box...]` -> `:children` -> `[]` -> etc

Notice that currently `rewrite-clj.zip/next` finds `#_[title :label "Hidden"]` and on the next iteration loops through `[title :label "Hidden"]`. This makes it hard for us to know if the current component is an uneval form or code to be executed.

This PR prevents the error from being thrown but prints to the console when an uneval form is found. 
In case the uneval form is a commented re-com component, it gets `:src` annotations added to it since rewrite-clj does not skip uneval forms as mentioned in [this issue](https://github.com/clj-commons/rewrite-clj/issues/70)