### PR TITLE
Ignore `p` and `p-span` components in add at macro script

### DIFF
--- a/scripts/add-at-macro/src/add_at_macro/core.clj
+++ b/scripts/add-at-macro/src/add_at_macro/core.clj
@@ -479,7 +479,10 @@
 (defn read-write-file
   "Reads and writes file in case of edits. When `verbose?` is true, operations that the script does are printed to the
    console. Or when `testing?` is true, it is the same as `verbose?` being true in that operations are printed to the
-   console and additionally edits are written to the console instead of files."
+   console and additionally edits are written to the console instead of files.
+   For testing purposes, you can pass a file as a string using the `test-file` argument. This is convenient for testing
+   when the script is not editing a file correctly or for studying the behavior of the `add-at-macro` script. An example
+   of how to do this can be found in the `add-at-macro.core-test` namespace at the test, `test-file`."
   [file {:keys [verbose? testing? test-file]}]
   (let [abs-path    (when-not test-file
                       (.getAbsolutePath ^File file))

--- a/scripts/add-at-macro/src/add_at_macro/core.clj
+++ b/scripts/add-at-macro/src/add_at_macro/core.clj
@@ -235,6 +235,19 @@
           z/up))
     loc))
 
+(defn re-com-component?
+  "Given a string and an alias, finds if the string is referring to a re-com component that should not be
+   added the `:src` annotations. i.e `p` or `p-span`.
+
+   For example
+   - Given the string `rc/p` and the alias `rc`, will return true
+   - Given the string `rc/p-span` and the alias `rc`, will return true
+   - Given any other string such as `rc/box` and an alias such as `rc` will return false"
+  [s alias]
+  (and (clojure.string/starts-with? s (str alias "/"))
+       (not= s (str alias "/p"))
+       (not= s (str alias "/p-span"))))
+
 (defn find-recom-usages
   "Given `loc` is a rewrite-clj zipper, it searches for hiccup vectors involving re-com components. For each one
   found, it calls `add-at-in-component` with that component to add `:src` to the arguments supplied.  As rewrite-clj
@@ -273,7 +286,7 @@
         ;; when re-com component ns is loaded with :as option
         (and (z/vector? loc) (seq (z/down loc))
              (not (clojure.string/starts-with? (-> loc z/down z/string) "#_")) ;; skip uneval forms
-             (-> loc z/down z/string (clojure.string/starts-with? (str (:used-alias parsed-require) "/"))))
+             (-> loc z/down z/string (re-com-component? (:used-alias parsed-require))))
         (recur (-> loc (add-at-in-component verbose?) z/next))
 
         :else

--- a/scripts/add-at-macro/src/add_at_macro/core.clj
+++ b/scripts/add-at-macro/src/add_at_macro/core.clj
@@ -242,14 +242,14 @@
           z/up))
     loc))
 
-(defn re-com-component?
+(defn re-com-kwargs-component?
   "Given a string and an alias, finds if the string is referring to a re-com component that should not be
    added the `:src` annotations. i.e `p` or `p-span`.
 
    For example
-   - Given the string `rc/p` and the alias `rc`, will return true
-   - Given the string `rc/p-span` and the alias `rc`, will return true
-   - Given any other string such as `rc/box` and an alias such as `rc` will return false"
+   - Given the string `rc/p` and the alias `rc`, will return false
+   - Given the string `rc/p-span` and the alias `rc`, will return false
+   - Given any other string such as `rc/box` and an alias such as `rc` will return true"
   [s alias]
   (and (clojure.string/starts-with? s (str alias "/"))
        (not= s (str alias "/p"))
@@ -296,7 +296,7 @@
         ;; when re-com component ns is loaded with :as option
         (and (z/vector? loc) (seq (z/down loc))
              (not (clojure.string/starts-with? (-> loc z/down z/string) "#_")) ;; skip uneval forms
-             (-> loc z/down z/string (re-com-component? (:used-alias parsed-require))))
+             (-> loc z/down z/string (re-com-kwargs-component? (:used-alias parsed-require))))
         (recur (-> loc (add-at-in-component verbose?) z/next))
 
         :else

--- a/scripts/add-at-macro/test/add_at_macro/core_test.clj
+++ b/scripts/add-at-macro/test/add_at_macro/core_test.clj
@@ -152,6 +152,15 @@
   (testing "Test getting function arguments."
     (is (z/vector? (arguments (z/down source-component))) "Could not get the function arguments.")))
 
+(def p-component (z/of-string "
+[rc/p-span        ;; also passes for `p`
+ :align :center
+ :children []]" {:track-position? true}))
+
+(deftest test-re-com-component?
+  (testing "Testing if this is a re-com component"
+    (is (not (re-com-component? (-> p-component z/down z/string) "rc")) "This is not a valid re-com component")))
+
 (def directory "")
 
 (deftest test-script

--- a/scripts/add-at-macro/test/add_at_macro/core_test.clj
+++ b/scripts/add-at-macro/test/add_at_macro/core_test.clj
@@ -186,12 +186,12 @@
 ")
 
 (deftest test-file
-  (testing "Testing effect of at macro script on a file."
+  (testing "Test effect of `add-at-macro` script on a string file."
     (read-write-file nil {:testing? true :test-file file-example})))
 
 
 (deftest test-script
-  (testing "Test the full script in general"
+  (testing "Test the full script including reading files from disk"
     ;; When `:print?` is true, this translates to verbose? in the script which is a flag to tell the script to print
     ;; to the console the changes it will do. When the flag `:testing?` is true, the console does not save the changes
     ;; it makes to file but prints the file to console. When `:testing?` is true, `:verbose?` is always true

--- a/scripts/add-at-macro/test/add_at_macro/core_test.clj
+++ b/scripts/add-at-macro/test/add_at_macro/core_test.clj
@@ -163,6 +163,33 @@
 
 (def directory "")
 
+(def file-example "
+(ns sample-namespace.core
+  (:require
+    [re-com.core :refer [box title p v-box] :as re-com]))
+
+(def test [re-com/title
+            :label \"Title\"])
+
+(defn a-function
+ [title]
+ [p \"Should not change.\"]
+ [title
+  :label \"Should not change.\"]
+ [v-box
+  :align :center
+  :children [[re-com/title
+              :label \"Title\"]]])
+
+(def test2 [title               <== Src will be added here.
+            :label \"Title\"])
+")
+
+(deftest test-file
+  (testing "Testing effect of at macro script on a file."
+    (read-write-file nil {:testing? true :test-file file-example})))
+
+
 (deftest test-script
   (testing "Test the full script in general"
     ;; When `:print?` is true, this translates to verbose? in the script which is a flag to tell the script to print

--- a/scripts/add-at-macro/test/add_at_macro/core_test.clj
+++ b/scripts/add-at-macro/test/add_at_macro/core_test.clj
@@ -47,10 +47,10 @@
     (with-redefs [recom-a recom-c]
       (test-append-at-to-refer-option))))
 
-(deftest test-remove-at-from-required-macros
+(deftest test-remove-at-from-require-macros
   (testing "Test removing at macro from re-com import form in require-macros `[re-com.core ...]`"
     (let [require-macro-a recom-b
-          edited-require  (remove-at-from-required-macros require-macro-a verbose?)
+          edited-require  (remove-at-from-require-macros require-macro-a verbose?)
           namespace       (-> edited-require z/down z/string)
           referred-vars   (-> edited-require (z/find-value z/next ':refer))
           referred-vars-a (when referred-vars
@@ -105,7 +105,7 @@
         (cond
           (z/end? loc) nil
           (find-re-com-in-require loc {:macros? true}) (with-redefs [recom-a loc]
-                                                         (test-remove-at-from-required-macros))
+                                                         (test-remove-at-from-require-macros))
           :else
           (recur (z/next loc)))))))
 
@@ -181,7 +181,7 @@
   :children [[re-com/title
               :label \"Title\"]]])
 
-(def test2 [title               <== Src will be added here.
+(def test2 [title               <== :src will be added here.
             :label \"Title\"])
 ")
 

--- a/scripts/add-at-macro/test/add_at_macro/core_test.clj
+++ b/scripts/add-at-macro/test/add_at_macro/core_test.clj
@@ -159,7 +159,7 @@
 
 (deftest test-re-com-component?
   (testing "Testing if this is a re-com component"
-    (is (not (re-com-component? (-> p-component z/down z/string) "rc")) "This is not a valid re-com component")))
+    (is (not (re-com-kwargs-component? (-> p-component z/down z/string) "rc")) "This is not a valid re-com component")))
 
 (def directory "")
 


### PR DESCRIPTION
Fixes #267 