### PR TITLE
Typo in core.cljs

### DIFF
--- a/src/re_demo/core.cljs
+++ b/src/re_demo/core.cljs
@@ -189,7 +189,7 @@
    :style   {:background-color "#666"}
    :children [[title
                :src   (at)
-               :label "Re-com"
+               :label "re-com"
                :level :level1
                :style {:font-size   "32px"
                        :color       "#fefefe"}]]])


### PR DESCRIPTION
Assuming that re-com is spelled all lower case, this is a typo.