### PR TITLE
Remove hardcoded `overflow` css  style in splits

### DIFF
--- a/src/re_com/splits.cljs
+++ b/src/re_com/splits.cljs
@@ -162,7 +162,6 @@
                                                                         (str "0 0 " percentage "px") ;; flex for panel-1
                                                                         (str "1 1 0px"))             ;; flex for panel-2
                                                                       (str percentage " 1 0px")))
-                                                  {:overflow "hidden"} ;; TODO: Shouldn't have this...test removing it
                                                   (when in-drag? {:pointer-events "none"})
                                                   style)}
                                    attr))
@@ -275,7 +274,6 @@
                                                                         (str "0 0 " percentage "px") ;; flex for panel-1
                                                                         (str "1 1 0px"))             ;; flex for panel-2
                                                                       (str percentage " 1 0px")))
-                                                  {:overflow "hidden"} ;; TODO: Shouldn't have this...test removing it
                                                   (when in-drag? {:pointer-events "none"})
                                                   style)}
                                    attr))

--- a/src/re_demo/splits.cljs
+++ b/src/re_demo/splits.cljs
@@ -78,11 +78,15 @@
                                       [h-split :src (at)
                                        :panel-1 [left-panel]
                                        :panel-2 [right-panel]
-                                       :size    "300px"]
+                                       :size    "300px"
+                                       :parts   {:top    {:style {:overflow :hidden}}
+                                                 :bottom {:style {:overflow :hidden}}}]
                                       [title :src (at) :level :level3 :label "[v-split]"]
                                       [v-split :src (at)
                                        :panel-1       [top-panel]
                                        :panel-2       [bottom-panel]
                                        :size          "300px"
-                                       :initial-split "25%"]]]]]
+                                       :initial-split "25%"
+                                       :parts         {:top    {:style {:overflow :hidden}}
+                                                       :bottom {:style {:overflow :hidden}}}]]]]]
               [parts-table "h-split" hv-split-parts-desc]]])


### PR DESCRIPTION
Fix #182 