### PR TITLE
Add link to re-com-tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ That number includes ReactJS plus the ClojureScript libs and runtime. So, everyt
 Note:  these numbers no longer match the demo app. We wanted to show off some of the debug features in our demo app, 
 so we backed away from fully advanced, minified compilation. 
 
+## re-com for tailwind
+
+[re-com-tailwind](https://github.com/BnMcGn/re-com-tailwind) - an edition of re-com that is compatible with tailwindcss - is available for testing.
+
 ## So, Without Ado Being Any Furthered ...
 
 Start by [looking at the demo](https://re-com.day8.com.au).


### PR DESCRIPTION
An edition of re-com for those who would prefer to use tailwindcss.

It's based on changes found in [PR #327](https://github.com/day8/re-com/pull/327). There's no immediate need to merge. For the time being, re-com-tailwind depends on a custom release of re-com.

Re-com-tailwind has proved usable for my personal project. It's about ready for more users and some augmented battering.
