### PR TITLE
Fix: Alert box style missing

### DIFF
--- a/src/re_com/alert.cljs
+++ b/src/re_com/alert.cljs
@@ -64,7 +64,7 @@
                                    :warning        "alert-warning"
                                    :danger         "alert-danger"})]
      [:div
-      (merge {:class (theme/merge-class "rc-alert" "alert" "fade in" "alert-class" class)
+      (merge {:class (theme/merge-class "rc-alert" "alert" "fade in" alert-class class)
               :style (merge (flex-child-style "none")
                             {:padding padding}
                             style)}


### PR DESCRIPTION
The alert boxes style is missing after 2.24.0 upgrade, specifically the style defined by the classes:

- alert-success
- alert-warning
- alert-danger

After a quick research what I can see is that in the namespace re-com.alert when setting the alert-class for the div of the alert-box, you use a piece of code like this in the let:

```
alert-class  (alert-type {:none           ""
                                   :info           "alert-success"
                                   :warning        "alert-warning"
                                   :danger         "alert-danger"})
```

But it is not being properly called at

`(theme/merge-class "rc-alert" "alert" "fade in" "alert-class" class)
`
It should be:

`(theme/merge-class "rc-alert" "alert" "fade in" alert-class class)`