### PR TITLE
Recent re-com work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.29.3 (...)
+
+#### Added
+- `re-com.debug`: emits a `:re-com/render` `re-frame.trace` event per component render carrying the component's `:src` metadata, for use by 10x panels, re-frame-pair, and similar tools. This is a no-op when `re-frame.trace` isn't loaded or tracing is disabled.
+
 ## 2.29.2 (2026-03-02)
 
 #### Fixed

--- a/demo/re_demo/debug.cljs
+++ b/demo/re_demo/debug.cljs
@@ -101,6 +101,16 @@
               [p "This links any DOM node you inspect in DevTool's \"Elements\" tab to the code which created it. "
                "When you are exploring an unfamiliar codebase (including your own, after an absence) this is invaluable. "
                "Just right-click and \"Inspect\" on any part of the apps UI and you can instantly see the coordinates for the underlying code."]
+              [title3 [:span [:code ":re-com/render"] " trace events"]]
+              [p "When " [:code ":src"] " is provided and " [:code "re-frame.trace"] " is loaded with tracing enabled, re-com also emits a "
+               [:code ":re-com/render"] " trace event for each instrumented component render."]
+              [p "The event uses " [:code ":op-type :re-com/render"] " and carries its source metadata under "
+               [:code ":tags"] ", shaped as "
+               [:code "{:component-name \"button\" :src {:file \"src/app.cljs\" :line 42}}"] "."]
+              [p "Downstream tools can recover the component source by correlating this event with Reagent's own "
+               [:code ":render"] " event using the same " [:code ":component-name"] " and a nearby "
+               [:code ":start"] " timestamp. Re-com does not require re-frame; without "
+               [:code "re-frame.trace"] " or when tracing is disabled, this path is a no-op."]
               [p [:b [:i "This feature is sufficiently useful that we recommend you leave your re-com code permanently instrumented with " [:code ":src"]]] ". Every single component, all the time. In production builds, the macro returns " [:code "nil"] " eliding any overhead. "]
               [title3 "A Script"]
               [p "If you have an existing/legacy codebase, "

--- a/src/re_com/debug.cljs
+++ b/src/re_com/debug.cljs
@@ -60,24 +60,40 @@
 ;; `:re-com/render` trace stream documented below. We resolve the
 ;; trace fns lazily via `goog.global` so re-com builds without
 ;; re-frame still compile and run cleanly.
-(def ^:private rf-trace
+;;
+;; Names looked up here are all `defn`/`def` in re-frame.trace and
+;; therefore exist as JS exports. `finish-trace` and `with-trace` in
+;; re-frame.trace are CLJ-only `defmacro`s wrapped in
+;; `(macros/deftime ...)` — they do NOT compile to JS exports, so
+;; resolving them dynamically returns undefined. Instead we inline
+;; the `finish-trace` macro's body using the exported `traces` atom
+;; and `run-tracing-callbacks!` fn.
+(def rf-trace
   ;; Cached so we don't walk goog.global on every render. Resets
   ;; to `:unset` on hot-reload (defonce semantics aren't appropriate
   ;; — re-frame may load AFTER re-com namespaces in some boot orders).
   (atom :unset))
 
-(defn- resolve-rf-trace! []
+(defn resolve-rf-trace! []
   (when-let [g (some-> js/goog .-global)]
     (when-let [tns (some-> g (gobj/get "re_frame") (gobj/get "trace"))]
-      (let [start    (gobj/get tns "start_trace")
-            finish   (gobj/get tns "finish_trace")
-            enabled? (gobj/get tns "is_trace_enabled_QMARK_")]
-        (when (and start finish enabled?)
-          {:start    start
-           :finish   finish
-           :enabled? enabled?})))))
+      (let [start            (gobj/get tns "start_trace")
+            enabled?         (gobj/get tns "is_trace_enabled_QMARK_")
+            traces           (gobj/get tns "traces")
+            run-tracing-cbs! (gobj/get tns "run_tracing_callbacks_BANG_")]
+        (when (and start enabled? traces run-tracing-cbs!)
+          {:start            start
+           :enabled?         enabled?
+           :traces           traces
+           :run-tracing-cbs! run-tracing-cbs!})))))
 
-(defn- emit-render-src-trace!
+(defn- now*
+  []
+  (if (and (exists? js/performance) (.-now js/performance))
+    (.now js/performance)
+    (.now js/Date)))
+
+(defn emit-render-src-trace!
   "Q1 result is NEGATIVE: Reagent's :render trace `:tags`
    carries only `:component-name` (10x's wrap-funs in
    day8/reagent/impl/component.cljs fires the `with-trace` with an
@@ -102,17 +118,19 @@
                    v))]
     (let [enabled? (:enabled? t)]
       (when (enabled?)
-        (let [start  (:start t)
-              finish (:finish t)
-              opts   #js {:op-type   :re-com/render
-                          :operation rc-component
-                          :tags      {:component-name rc-component
-                                      :src            src}}
-              ;; start-trace returns a trace map; finish-trace
-              ;; expects it back. We don't run a body — the trace
-              ;; is a marker, so duration is effectively 0.
-              tr     (start (cljs.core/js->clj opts :keywordize-keys true))]
-          (finish tr))))))
+        (let [start            (:start t)
+              traces-atom      (:traces t)
+              run-tracing-cbs! (:run-tracing-cbs! t)
+              tr               (start {:op-type   :re-com/render
+                                       :operation rc-component
+                                       :tags      {:component-name rc-component
+                                                   :src            src}})
+              end              (now*)
+              finished         (assoc tr
+                                      :duration (- end (:start tr))
+                                      :end      end)]
+          (swap! traces-atom conj finished)
+          (run-tracing-cbs! end))))))
 
 (defn ->attr
   [{:keys [src debug-as] :as args}]

--- a/src/re_com/debug.cljs
+++ b/src/re_com/debug.cljs
@@ -53,7 +53,7 @@
       (handler-fn (log-on-alt-click* event (cond-> args (not show-all-args?) loggable-args)))
       nil)))
 
-;; rc-aeh — runtime probe for re-frame.trace. Re-com intentionally
+;; Runtime probe for re-frame.trace. Re-com intentionally
 ;; doesn't depend on re-frame (re-frame-10x inlines its own copy via
 ;; mranderson, so 10x as a peer dep doesn't carry re-frame), but
 ;; consumer apps that do load re-frame can opt in to the
@@ -78,7 +78,7 @@
            :enabled? enabled?})))))
 
 (defn- emit-render-src-trace!
-  "rc-aeh — Q1 result is NEGATIVE: Reagent's :render trace `:tags`
+  "Q1 result is NEGATIVE: Reagent's :render trace `:tags`
    carries only `:component-name` (10x's wrap-funs in
    day8/reagent/impl/component.cljs fires the `with-trace` with an
    empty body before `do-render`, so hiccup-metadata via

--- a/src/re_com/debug.cljs
+++ b/src/re_com/debug.cljs
@@ -53,6 +53,67 @@
       (handler-fn (log-on-alt-click* event (cond-> args (not show-all-args?) loggable-args)))
       nil)))
 
+;; rc-aeh — runtime probe for re-frame.trace. Re-com intentionally
+;; doesn't depend on re-frame (re-frame-10x inlines its own copy via
+;; mranderson, so 10x as a peer dep doesn't carry re-frame), but
+;; consumer apps that do load re-frame can opt in to the
+;; `:re-com/render` trace stream documented below. We resolve the
+;; trace fns lazily via `goog.global` so re-com builds without
+;; re-frame still compile and run cleanly.
+(def ^:private rf-trace
+  ;; Cached so we don't walk goog.global on every render. Resets
+  ;; to `:unset` on hot-reload (defonce semantics aren't appropriate
+  ;; — re-frame may load AFTER re-com namespaces in some boot orders).
+  (atom :unset))
+
+(defn- resolve-rf-trace! []
+  (when-let [g (some-> js/goog .-global)]
+    (when-let [tns (some-> g (gobj/get "re_frame") (gobj/get "trace"))]
+      (let [start    (gobj/get tns "start_trace")
+            finish   (gobj/get tns "finish_trace")
+            enabled? (gobj/get tns "is_trace_enabled_QMARK_")]
+        (when (and start finish enabled?)
+          {:start    start
+           :finish   finish
+           :enabled? enabled?})))))
+
+(defn- emit-render-src-trace!
+  "rc-aeh — Q1 result is NEGATIVE: Reagent's :render trace `:tags`
+   carries only `:component-name` (10x's wrap-funs in
+   day8/reagent/impl/component.cljs fires the `with-trace` with an
+   empty body before `do-render`, so hiccup-metadata via
+   `(with-meta [:div ...] {:src ...})` never reaches it). The
+   workaround is a sibling marker trace: zero-body `with-trace`
+   carrying `:src` + `:component-name`, fired once per `->attr`
+   call. Consumers (re-frame-pair, custom 10x panels) correlate
+   `:re-com/render` to the matching `:render` by component-name
+   + nearby `:start` timestamp.
+
+   No-op when re-frame.trace isn't loaded into the runtime —
+   re-com stays decoupled from re-frame as a hard dep.
+   No-op when tracing is disabled (`trace-enabled?` false) —
+   matches re-frame.trace's own gating semantics."
+  [rc-component src]
+  (when-let [t (let [v @rf-trace]
+                 (if (= :unset v)
+                   (let [r (resolve-rf-trace!)]
+                     (reset! rf-trace r)
+                     r)
+                   v))]
+    (let [enabled? (:enabled? t)]
+      (when (enabled?)
+        (let [start  (:start t)
+              finish (:finish t)
+              opts   #js {:op-type   :re-com/render
+                          :operation rc-component
+                          :tags      {:component-name rc-component
+                                      :src            src}}
+              ;; start-trace returns a trace map; finish-trace
+              ;; expects it back. We don't run a body — the trace
+              ;; is a marker, so duration is effectively 0.
+              tr     (start (cljs.core/js->clj opts :keywordize-keys true))]
+          (finish tr))))))
+
 (defn ->attr
   [{:keys [src debug-as] :as args}]
   (if-not debug? ;; This is in a separate `if` so Google Closure dead code elimination can run...
@@ -76,6 +137,7 @@
                                   (when (fn? user-ref-fn)
                                     (user-ref-fn el))))
           {:keys [file line]} src]
+      (when src (emit-render-src-trace! rc-component src))
       (cond->
        {:ref     ref-fn
         :data-rc rc-component}

--- a/test/re_com/debug_test.cljs
+++ b/test/re_com/debug_test.cljs
@@ -1,0 +1,94 @@
+(ns re-com.debug-test
+  (:require [cljs.test     :refer-macros [is deftest testing use-fixtures]]
+            [goog.object   :as gobj]
+            [re-com.debug  :as debug]))
+
+(defn- with-fake-rf-trace
+  "Install a fake `re_frame.trace` ns on goog.global that mirrors what
+   the real re-frame ships when compiled to JS: only `defn`/`def`
+   exports are present. Notably, `finish_trace` is absent — it's a
+   macro in re-frame.trace and never compiles into the JS namespace.
+   Returns the fake `traces` atom so the test can assert against it."
+  [{:keys [enabled?]}]
+  (let [traces           (atom [])
+        cb-calls         (atom [])
+        next-id          (atom 0)
+        start-trace      (fn [{:keys [operation op-type tags child-of]}]
+                           {:id        (swap! next-id inc)
+                            :operation operation
+                            :op-type   op-type
+                            :tags      tags
+                            :child-of  child-of
+                            :start     (.now js/performance)})
+        run-tracing-cbs! (fn [now] (swap! cb-calls conj now))
+        rf               #js {}
+        rf-trace         #js {}]
+    (gobj/set rf-trace "start_trace" start-trace)
+    (gobj/set rf-trace "is_trace_enabled_QMARK_" (fn [] (boolean enabled?)))
+    (gobj/set rf-trace "traces" traces)
+    (gobj/set rf-trace "run_tracing_callbacks_BANG_" run-tracing-cbs!)
+    (gobj/set rf "trace" rf-trace)
+    (gobj/set js/goog.global "re_frame" rf)
+    {:traces traces :cb-calls cb-calls}))
+
+(defn- clear-fake-rf-trace! []
+  (gobj/remove js/goog.global "re_frame")
+  (reset! debug/rf-trace :unset))
+
+(use-fixtures :each
+  {:before clear-fake-rf-trace!
+   :after  clear-fake-rf-trace!})
+
+(deftest emit-render-src-trace-fires-without-finish-trace-export
+  (testing "Regression: finish-trace is a CLJ-only macro and is NOT a JS
+            export of re-frame.trace. Resolving it via gobj/get returns
+            undefined, which previously caused emit-render-src-trace! to
+            silently no-op for every consumer."
+    (let [{:keys [traces cb-calls]} (with-fake-rf-trace {:enabled? true})
+          src                       {:file "src/foo.cljs" :line 42}]
+      (debug/emit-render-src-trace! "foo-component" src)
+      (is (= 1 (count @traces))
+          "exactly one :re-com/render trace lands in re-frame's traces atom")
+      (let [t (first @traces)]
+        (is (= :re-com/render (:op-type t)))
+        (is (= "foo-component" (:operation t)))
+        (is (= {:component-name "foo-component" :src src} (:tags t)))
+        (is (number? (:start t)))
+        (is (number? (:end t)))
+        (is (number? (:duration t)))
+        (is (>= (:duration t) 0)
+            "duration uses the same clock at both endpoints"))
+      (is (= 1 (count @cb-calls))
+          "run-tracing-callbacks! is invoked exactly once per emit"))))
+
+(deftest emit-render-src-trace-no-op-when-tracing-disabled
+  (testing "Matches re-frame.trace's gating semantics: when
+            (is-trace-enabled?) returns false, no trace is emitted."
+    (let [{:keys [traces cb-calls]} (with-fake-rf-trace {:enabled? false})]
+      (debug/emit-render-src-trace! "foo-component" {:file "x" :line 1})
+      (is (zero? (count @traces)))
+      (is (zero? (count @cb-calls))))))
+
+(deftest emit-render-src-trace-no-op-when-rf-trace-not-loaded
+  (testing "When re-frame.trace isn't on goog.global, resolution
+            returns nil and emit-render-src-trace! is silently no-op
+            (re-com stays decoupled from re-frame as a hard dep)."
+    ;; clear-fake-rf-trace! has already removed re_frame from goog.global.
+    (debug/emit-render-src-trace! "foo-component" {:file "x" :line 1})
+    (is (nil? @debug/rf-trace)
+        "cache resolves to nil when re-frame.trace is absent")))
+
+(deftest resolve-rf-trace-requires-all-exports
+  (testing "If any of the four exports is missing, resolution returns
+            nil so the caller can skip cleanly. Notably this protects
+            against a future re-frame.trace dropping or renaming one
+            of (start-trace, is-trace-enabled?, traces,
+            run-tracing-callbacks!)."
+    (doseq [missing ["start_trace" "is_trace_enabled_QMARK_"
+                     "traces" "run_tracing_callbacks_BANG_"]]
+      (with-fake-rf-trace {:enabled? true})
+      (gobj/remove (.. js/goog.global -re_frame -trace) missing)
+      (reset! debug/rf-trace :unset)
+      (is (nil? (debug/resolve-rf-trace!))
+          (str "resolution fails when " missing " is absent"))
+      (clear-fake-rf-trace!))))

--- a/test/re_com/debug_test.cljs
+++ b/test/re_com/debug_test.cljs
@@ -1,6 +1,7 @@
 (ns re-com.debug-test
   (:require [cljs.test     :refer-macros [is deftest testing use-fixtures]]
             [goog.object   :as gobj]
+            [re-com.config :as config]
             [re-com.debug  :as debug]))
 
 (defn- with-fake-rf-trace
@@ -38,6 +39,33 @@
 (use-fixtures :each
   {:before clear-fake-rf-trace!
    :after  clear-fake-rf-trace!})
+
+(deftest ->attr-returns-empty-when-debug-false
+  (testing "Closure dead-code-elim guard: when re-com.config/debug?
+            (i.e. goog.DEBUG) is false, ->attr returns {} immediately
+            so production builds pay none of the ref/component-name
+            cost. The (if-not debug? ...) form is split out for this
+            reason — see the comment in src/re_com/debug.cljs."
+    (with-redefs [config/debug? false]
+      (is (= {} (debug/->attr {:src      {:file "src/foo.cljs" :line 42}
+                               :debug-as {:component "foo-component"}}))))))
+
+(deftest ->attr-returns-data-rc-and-data-rc-src-when-src-present
+  (testing "Happy path: with debug? true and :src supplied, ->attr
+            returns :ref + :data-rc (component name) + :data-rc-src
+            (\"file:line\"). :debug-as {:component ...} is supplied so
+            the test can run outside a Reagent render — otherwise
+            ->attr falls back to (r/current-component) which only
+            exists during a render."
+    (let [src   {:file "src/foo.cljs" :line 42}
+          attrs (debug/->attr {:src      src
+                               :debug-as {:component "foo-component"}})]
+      (is (fn? (:ref attrs))
+          ":ref is the callback ref re-com installs to capture rc-args on the DOM node")
+      (is (= "foo-component" (:data-rc attrs))
+          ":data-rc carries the component name for DevTools / component-stack")
+      (is (= "src/foo.cljs:42" (:data-rc-src attrs))
+          ":data-rc-src serializes :src as \"file:line\" for source-map navigation"))))
 
 (deftest emit-render-src-trace-fires-without-finish-trace-export
   (testing "Regression: finish-trace is a CLJ-only macro and is NOT a JS


### PR DESCRIPTION
## Summary

Bundles the recent local work in `re-com` for review.

## Commit Range

- Base: `origin/master`
- Commits: `5`

## Recent Commits

- 685f818b docs(debug): document render trace surface
- ab16ba28 test(debug): cover ->attr's debug? short-circuit and :src happy path (rc-zth)
- 961b9215 fix(debug): resolve `:re-com/render` trace via exported fns, not the `finish-trace` macro
- 726be8ed refactor: strip bead-ID prefixes from code comments
- b3912727 rc-aeh: emit :re-com/render trace carrying :src from ->attr

## Validation

- Not run as part of PR creation.
