### PR TITLE
Fix popover-anchor-wrapper for positional-args :popover style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.29.4 (Unreleased)
+
+#### Fixed
+- `popover-anchor-wrapper`: `:popover` argument using positional-args calling style `[popover-fn arg1 arg2 ...]` no longer breaks `:showing-injected?`/`:position-injected` injection. Previously the non-keyword branch wrapped the call as a single map, causing the receiving fn's `[a b & {:keys [...]}]` destructure to bind `a` to the entire map and produce nil kwargs — visible as a 💥 in the "Complex Popover (dialog box)" demo. Map-style invocation `[popover-fn {props}]` continues to work. [#367](https://github.com/day8/re-com/issues/367)
+
 ## 2.29.3 (2026-04-29)
 
 #### Added

--- a/src/re_com/popover.cljs
+++ b/src/re_com/popover.cljs
@@ -578,7 +578,7 @@
             (let [[orientation _arrow-pos] (split-keyword @internal-position "-") ;; only need orientation here
                   place-anchor-before?    (case orientation (:left :above) false true)
                   flex-flow               (case orientation (:left :right) "row" "column")
-                  [popover-fn & {:as popover-args}] popover]
+                  popover-fn               (first popover)]
               [:div
                (merge {:class (theme/merge-class "rc-popover-anchor-wrapper"
                                                  "display-inline-flex"
@@ -607,12 +607,17 @@
                                    :z-index  4}
                                   (get-in parts [:point :style]))
                     :attr  (get-in parts [:point :attr])}
-                   (if (keyword? (get popover 1))
+                   (cond
+                     (keyword? (get popover 1))
                      (into popover [:showing-injected? showing?
                                     :position-injected internal-position])
-                     [popover-fn (merge popover-args
+                     (map? (get popover 1))
+                     [popover-fn (merge (get popover 1)
                                         {:showing-injected? showing?
-                                         :position-injected internal-position})])])
+                                         :position-injected internal-position})]
+                     :else
+                     (into popover [:showing-injected? showing?
+                                    :position-injected internal-position]))])
                 (when-not place-anchor-before? anchor)]]))))}))))
 
 ;;--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #367

## Summary

When `:popover` is invoked with positional args (`[popover-fn arg1 arg2 ...]`), the else-branch of the existing keyword? check re-wrapped the call as a single-map invocation. The receiving fn's `[a b & {:keys [...]}]` destructure then bound `a` to the entire map and produced nil kwargs — `popover-content-wrapper` failed validation on the nil `:position-injected` and rendered 💥 instead of the popover body.

Replaced the if/else with a `cond` that distinguishes three cases:

- `keyword?` first item → keyword args style → append injected kwargs via `into` (existing behaviour)
- `map?` first item → single-map style → merge injected kwargs into the map (existing behaviour, added with map-style support)
- else → positional args → append injected kwargs via `into` (restored original pre-map-support behaviour). Reagent supports `[fn pos1 pos2 :kw v]` and the receiving fn's positional + kwarg destructure handles it correctly.

`popover-args` was the trailing-kwargs destructure that's only needed for the keyword-args case via `into`; it's no longer used after the fix, replaced with a simple `(first popover)` for `popover-fn`.

## Test plan

- [x] `bb watch` compile clean (0 warnings)
- [x] Playwright check on `#/popovers`: clicking "Dialog box" now renders the dialog popover correctly (title, body, Apply/Cancel, backdrop, nested "popover over a popover"). 0 page errors, 0 validation warnings, 0 💥 indicators.
- [x] Simple `[popover-anchor-wrapper :popover [popover-content-wrapper :title ... :body ...]]` (keyword-args case) still works — verified visually on the same page.

Before/after screenshot of the dialog popover on `#/popovers`:

| Before | After |
|--------|-------|
| 💥 in place of popover body | Full dialog renders: title, radios, Apply/Cancel, backdrop, nested cancel-button popover |