### PR TITLE
Surface :validate-fn-return errors instead of "Unknown problem reported"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Fixed
 - `popover-anchor-wrapper`: `:popover` argument using positional-args calling style `[popover-fn arg1 arg2 ...]` no longer breaks `:showing-injected?`/`:position-injected` injection. Previously the non-keyword branch wrapped the call as a single map, causing the receiving fn's `[a b & {:keys [...]}]` destructure to bind `a` to the entire map and produce nil kwargs — visible as a 💥 in the "Complex Popover (dialog box)" demo. Map-style invocation `[popover-fn {props}]` continues to work. [#367](https://github.com/day8/re-com/issues/367)
+- `re-com.debug`: validation logger now reports `:validate-fn-return` problems with the validator's actual error message instead of an unhelpful "Unknown problem reported". This affected any validator built on `validate-arg-against-set` (e.g. `position?`, `justify-style?`, `alert-type?`) when a value didn't match the expected set — the error string was being computed but never shown. [#368](https://github.com/day8/re-com/issues/368)
 
 ## 2.29.3 (2026-04-29)
 

--- a/src/re_com/debug.cljs
+++ b/src/re_com/debug.cljs
@@ -230,7 +230,6 @@
   [problems]
   (doseq [{:keys [problem arg-name expected actual validate-fn-result]} problems]
     (case problem
-      ;; [IJ] TODO: :validate-fn-return
       :unknown
       (js/console.log
        (str "• %cUnknown parameter: %c" arg-name)
@@ -254,6 +253,13 @@
       :validate-fn-map
       (js/console.log
        (str "• %c" (:message validate-fn-result))
+       error-style)
+
+      :validate-fn-return
+      (js/console.log
+       (str "• %c" (if (string? validate-fn-result)
+                     validate-fn-result
+                     (str "Parameter " arg-name " failed validation: " (pr-str validate-fn-result))))
        error-style)
 
       :part-top-level-collision


### PR DESCRIPTION
Closes #368

## Summary

`log-validate-args-error-problems` had no `case` branch for the `:validate-fn-return` problem type, so the validator's actual error message was computed (and attached to `:validate-fn-result`) but never shown — only the unhelpful default "Unknown problem reported" surfaced. There was a `;; [IJ] TODO: :validate-fn-return` comment confirming the gap.

This affects every validator built on `validate-arg-against-set`: `position?`, `justify-style?`, `align-style?`, `scroll-style?`, `alert-type?`, `popover-status-type?`, `button-size?`, `throbber-size?`, `input-status-type?`, `title-level?`. Each returns either `true` or a string like `"Invalid :position. Expected one of [...]. Got 'foo'"` — that string is now shown directly.

## Before/after

**Before**:
```
• 😕 Unknown problem reported
```

**After** (e.g. for an out-of-set position):
```
• Invalid :position. Expected one of [:above-left :above-center ...]. Got ''
```

## Test plan

- [x] `bb watch` compile clean (0 warnings)
- [x] Existing recognised problem types (`:unknown`, `:required`, `:ref`, `:validate-fn`, `:validate-fn-map`, `:part-top-level-collision`, `:part-top-level-unsupported`, `:part-req-missing`) unchanged
- [x] When `:validate-fn-result` is non-string, falls back to `"Parameter X failed validation: <pr-str>"`