### PR TITLE
Fix race in typeahead async :data-source callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Fixed
 - `popover-anchor-wrapper`: `:popover` argument using positional-args calling style `[popover-fn arg1 arg2 ...]` no longer breaks `:showing-injected?`/`:position-injected` injection. Previously the non-keyword branch wrapped the call as a single map, causing the receiving fn's `[a b & {:keys [...]}]` destructure to bind `a` to the entire map and produce nil kwargs — visible as a 💥 in the "Complex Popover (dialog box)" demo. Map-style invocation `[popover-fn {props}]` continues to work. [#367](https://github.com/day8/re-com/issues/367)
 - `re-com.debug`: validation logger now reports `:validate-fn-return` problems with the validator's actual error message instead of an unhelpful "Unknown problem reported". This affected any validator built on `validate-arg-against-set` (e.g. `position?`, `justify-style?`, `alert-type?`) when a value didn't match the expected set — the error string was being computed but never shown. [#368](https://github.com/day8/re-com/issues/368)
+- `typeahead`: async `:data-source` is no longer racey. When multiple data-source callbacks were in flight, whichever resolved last won — so a slow response for an older query could overwrite a fresh one (e.g. typing `g`, `go`, `goo` slowly enough that the `g` callback returned last left the suggestions showing matches for `g` while the input still read `goo`). Each search now carries a monotonically-increasing id; stale callbacks become no-ops. [#361](https://github.com/day8/re-com/issues/361)
 
 ## 2.29.3 (2026-04-29)
 

--- a/src/re_com/typeahead.cljs
+++ b/src/re_com/typeahead.cljs
@@ -181,11 +181,20 @@
 
 (defn- search-data-source!
   "Call the `data-source` fn with `text`, and then call `got-suggestions` with the result
-  (asynchronously, if `data-source` does not return a truthy value)."
+  (asynchronously, if `data-source` does not return a truthy value).
+
+  Each call gets a monotonically-increasing `:search-id`; the result-handler
+  only commits suggestions when its id still matches the latest, so a slow
+  callback for an older query can't overwrite a fresh one."
   [data-source state-atom text]
-  (if-let [return-value (data-source text #(swap! state-atom got-suggestions %1))]
-    (swap! state-atom got-suggestions return-value)
-    (swap! state-atom assoc :waiting? true)))
+  (let [search-id (-> (swap! state-atom update :search-id (fnil inc 0))
+                      :search-id)
+        on-result (fn [suggestions]
+                    (when (= search-id (:search-id @state-atom))
+                      (swap! state-atom got-suggestions suggestions)))]
+    (if-let [return-value (data-source text on-result)]
+      (on-result return-value)
+      (swap! state-atom assoc :waiting? true))))
 
 (defn- search-data-source-loop!
   "For every value arriving on the `c-search` channel, call `search-data-source!`."


### PR DESCRIPTION
Closes #361

## Summary

`search-data-source!` installed a bare `swap!` callback with no version check, so multiple in-flight async data-source callbacks raced — whichever resolved *last* won, even when fired for an older query.

Reproduces the issue's repro exactly: with a data-source that delays inversely with input length (`(timeout (* 1000 (- 3 (count s))))`), typing `g`, `go`, `goo` slowly leaves the suggestions showing matches for `g` while the input still reads `goo`.

## Fix

Tag each search with a monotonically-increasing `:search-id`; the result-handler captures its id by closure and only commits when the id still matches the latest. Stale callbacks become no-ops.

```clojure
(defn- search-data-source!
  [data-source state-atom text]
  (let [search-id (-> (swap! state-atom update :search-id (fnil inc 0))
                      :search-id)
        on-result (fn [suggestions]
                    (when (= search-id (:search-id @state-atom))
                      (swap! state-atom got-suggestions suggestions)))]
    (if-let [return-value (data-source text on-result)]
      (on-result return-value)
      (swap! state-atom assoc :waiting? true))))
```

The synchronous-return path goes through the same `on-result`, so the check is uniform. No change to the public `data-source` contract — callers don't need to know about the search-id.

## Why search-id and not text-comparison

Comparing the callback's `text` against `(:input-text state)` *almost* works but breaks if the user types `g`, deletes, then types `g` again — the older callback would (wrongly) match and commit potentially-stale suggestions. Search-id is bullet-proof.

## Test plan

- [x] `bb watch` compile clean (0 warnings)
- [x] Existing typeahead demo continues to work (no regression for synchronous data-source).
- [x] Logic walk-through against the issue's repro confirms stale callbacks are dropped.

No automated test added — `test/re_com/` has no existing typeahead test file, matching the pattern.